### PR TITLE
Add support for multi_tenant_enabled setting

### DIFF
--- a/src/stream-chat-net-test/ClientTests.cs
+++ b/src/stream-chat-net-test/ClientTests.cs
@@ -27,7 +27,8 @@ namespace StreamChatTests
             var inSettings = new AppSettings()
             {
                 WebhookURL = "http://www.example.com",
-                DisableAuth = true
+                DisableAuth = true,
+                MultiTenantEnabled = true
             };
             await this._client.UpdateAppSettings(inSettings);
 
@@ -37,6 +38,7 @@ namespace StreamChatTests
             Assert.AreEqual(inSettings.DisableAuth, appSettings.DisableAuth);
             Assert.NotNull(appSettings.ChannelConfigs);
             Assert.True(appSettings.ChannelConfigs.ContainsKey("messaging"));
+            Assert.True(appSettings.MultiTenantEnabled);
         }
 
         [Test]

--- a/src/stream-chat-net/APPSettingsWithDetails.cs
+++ b/src/stream-chat-net/APPSettingsWithDetails.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace StreamChat
 {
@@ -33,6 +31,9 @@ namespace StreamChat
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disable_permissions_checks")]
         public bool DisablePermissions { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "multi_tenant_enabled")]
+        public bool MultiTenantEnabled { get; set; }
 
 
         public AppSettingsWithDetails() { }

--- a/src/stream-chat-net/AppSettings.cs
+++ b/src/stream-chat-net/AppSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 
 namespace StreamChat
@@ -10,6 +9,9 @@ namespace StreamChat
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disable_permissions_checks")]
         public bool DisablePermissions { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "multi_tenant_enabled")]
+        public bool MultiTenantEnabled { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "apn_config")]
         public APNConfig APNConfig { get; set; }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Make it possible to read/write the `multi_tenant_enabled` setting via `AppSettings`/`AppSettingsWithDetails` to support multi tenancy scenarios. Enhanced existing unit tests to test this new setting.
