### PR TITLE
Change JsonHelper's FromJObject method to use compiled and cached expression trees

### DIFF
--- a/src/stream-chat-net-test/JsonHelperTests.cs
+++ b/src/stream-chat-net-test/JsonHelperTests.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using StreamChat;
 using System;
-using System.Diagnostics;
 using System.Linq;
 
 namespace StreamChatTests
@@ -10,48 +9,6 @@ namespace StreamChatTests
     [TestFixture]
     public class JsonHelperTests
     {
-        [Test]
-        public void TestSpeed()
-        {
-            JsonHelpers.RegisterType<Attachment>();
-
-            var orig = CreateTestAttachment();
-            var copy = new Attachment();
-
-            var testObject = orig.ToJObject();
-            testObject.Add("TestProperty", JToken.FromObject(DateTime.Now));
-
-            var count = 5000;
-
-            var sw = new Stopwatch();
-            sw.Start();
-
-            for (int i = 0; i < count; i++)
-            {
-                JsonHelpers.FromJObject(copy, testObject);
-            }
-
-            sw.Stop();
-
-            var expressionTime = sw.ElapsedMilliseconds;
-            Debug.WriteLine(expressionTime);
-
-            copy = new Attachment();
-
-            sw.Restart();
-
-            for (int i = 0; i < count; i++)
-            {
-                JsonHelpers.FromJObjectOld(copy, testObject);
-            }
-
-            sw.Stop();
-            var origTime = sw.ElapsedMilliseconds;
-            Debug.WriteLine(origTime);
-
-            Assert.Less(expressionTime, origTime);
-        }
-
         [TestCase]
         public void TestCorrectness()
         {

--- a/src/stream-chat-net-test/JsonHelperTests.cs
+++ b/src/stream-chat-net-test/JsonHelperTests.cs
@@ -1,0 +1,154 @@
+﻿using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using StreamChat;
+using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace StreamChatTests
+{
+    [TestFixture]
+    public class JsonHelperTests
+    {
+        [Test]
+        public void TestSpeed()
+        {
+            JsonHelpers.RegisterType<Attachment>();
+
+            var orig = CreateTestAttachment();
+            var copy = new Attachment();
+
+            var testObject = orig.ToJObject();
+            testObject.Add("TestProperty", JToken.FromObject(DateTime.Now));
+
+            var count = 5000;
+
+            var sw = new Stopwatch();
+            sw.Start();
+
+            for (int i = 0; i < count; i++)
+            {
+                JsonHelpers.FromJObject(copy, testObject);
+            }
+
+            sw.Stop();
+
+            var expressionTime = sw.ElapsedMilliseconds;
+            Debug.WriteLine(expressionTime);
+
+            copy = new Attachment();
+
+            sw.Restart();
+
+            for (int i = 0; i < count; i++)
+            {
+                JsonHelpers.FromJObjectOld(copy, testObject);
+            }
+
+            sw.Stop();
+            var origTime = sw.ElapsedMilliseconds;
+            Debug.WriteLine(origTime);
+
+            Assert.Less(expressionTime, origTime);
+        }
+
+        [TestCase]
+        public void TestCorrectness()
+        {
+            var orig = CreateTestAttachment();
+
+            var testObject = orig.ToJObject();
+
+            var now = DateTime.Now;
+            var testPropName = "TestProperty";
+
+            testObject.Add(testPropName, JToken.FromObject(now));
+
+            var copy = new Attachment();
+
+            var extraData = JsonHelpers.FromJObject(copy, testObject);
+
+            Assert.IsTrue(AreEqual(orig, copy));
+            Assert.AreEqual(now, extraData.GetData<DateTime>(testPropName));
+        }
+
+        private static Attachment CreateTestAttachment()
+        {
+            return new Attachment
+            {
+                Actions = new System.Collections.Generic.List<AttachmentAction>
+                {
+                    new AttachmentAction
+                    {
+                        Name = "AttachmentAction",
+                        Style = "AttachmentActionStyle",
+                        Text = "AttachmentActionText",
+                        Type = "AttachmentActionType",
+                        Value = "AttachmentActionValue"
+                    }
+                },
+                AssetURL = "AssetURL",
+                Type = "Type",
+                Text = "Text",
+                AuthorIcon = "AuthorIcon",
+                AuthorLink = "AuthorLink",
+                AuthorName = "AuthorName",
+                Color = "Color",
+                Fallback = "Fallback",
+                Fields = new System.Collections.Generic.List<Field>
+                {
+                    new Field
+                    {
+                        Short = true,
+                        Title = "Title",
+                        Value = "Value"
+                    }
+                },
+                Title = "Title",
+                Footer = "Footer",
+                FooterIcon = "FooterIcon ",
+                ImageURL = "ImageURL",
+                OGScrapeUrl = "OGScrapeUrl ",
+                Pretext = "Pretext",
+                ThumbURL = "ThumbURL",
+                TitleLink = null
+            };
+        }
+
+        private bool AreEqual(Attachment orig, Attachment copy)
+        {
+            return orig.Actions
+                .Zip(copy.Actions, (a1, a2) =>
+                    a1.Name == a2.Name
+                    && a1.Style == a2.Style
+                    && a1.Text == a2.Text
+                    && a1.Type == a2.Type
+                    && a1.Value == a2.Value
+                    )
+                .All(x => x)
+                && orig.AssetURL == copy.AssetURL
+                && orig.AuthorIcon == copy.AuthorIcon
+                && orig.AuthorLink == copy.AuthorLink
+                && orig.AuthorName == copy.AuthorName
+                && orig.Color == copy.Color
+                && orig.Fallback == copy.Fallback
+                && orig.Fields
+                .Zip(copy.Fields, (f1, f2) =>
+                    f1.Short == f2.Short
+                    && f1.Title == f2.Title
+                    && f1.Value == f2.Value
+                    )
+                .All(x => x)
+                && orig.Footer == copy.Footer
+                && orig.FooterIcon == copy.FooterIcon
+                && orig.ImageURL == copy.ImageURL
+                && orig.OGScrapeUrl == copy.OGScrapeUrl
+                && orig.Pretext == copy.Pretext
+                && orig.Text == copy.Text
+                && orig.ThumbURL == copy.ThumbURL
+                && orig.Title == copy.Title
+                && orig.TitleLink == copy.TitleLink
+                && orig.Type == copy.Type;
+        }
+    }
+}

--- a/src/stream-chat-net/CustomDataBase.cs
+++ b/src/stream-chat-net/CustomDataBase.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json.Linq;
+
+namespace StreamChat
+{
+    public class CustomDataBase
+    {
+        protected GenericData _data = new GenericData();
+
+        public CustomDataBase() { }
+
+        public T GetData<T>(string name)
+        {
+            return this._data.GetData<T>(name);
+        }
+
+        public void SetData<T>(string name, T data)
+        {
+            this._data.SetData(name, data);
+        }
+
+        internal JObject ToJObject()
+        {
+            var root = JObject.FromObject(this);
+            this._data.AddToJObject(root);
+            return root;
+        }
+    }
+}

--- a/src/stream-chat-net/JSONHelpers.cs
+++ b/src/stream-chat-net/JSONHelpers.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Linq.Expressions;
+using System.Collections;
 
 namespace StreamChat
 {
@@ -33,15 +35,133 @@ namespace StreamChat
 
     internal class JsonHelpers
     {
+        private delegate GenericData Builder<T>(T target, IEnumerable<JProperty> jsonProps);
+
+        private static readonly Dictionary<Type, object> CachedBuilders = new Dictionary<Type, object>();
+
         internal static GenericData FromJObject<T>(T obj, JObject json)
         {
-#if NETSTANDARD1_6
-            PropertyInfo[] properties = typeof(T).GetTypeInfo().GetProperties();
-#else
-            PropertyInfo[] properties = typeof(T).GetProperties();
-#endif
-            Dictionary<string, PropertyInfo> objProps = new Dictionary<string, PropertyInfo>();
-            GenericData extra = new GenericData();
+            var jProps = json.Properties();
+
+            if (CachedBuilders.TryGetValue(typeof(T), out var builder))
+                return (builder as Builder<T>)(obj, jProps);
+
+            var properties = typeof(T).GetPropertiesPortable();
+
+            var newBuilder = ConstructBuilder<T>(properties);
+
+            CachedBuilders[typeof(T)] = newBuilder;
+
+            return newBuilder(obj, jProps);
+        }
+
+        internal static void RegisterType<T>()
+        {
+            if (CachedBuilders.ContainsKey(typeof(T)))
+                return;
+
+            var properties = typeof(T).GetPropertiesPortable();
+
+            var newBuilder = ConstructBuilder<T>(properties);
+
+            CachedBuilders[typeof(T)] = newBuilder;
+        }
+
+        private static Builder<T> ConstructBuilder<T>(PropertyInfo[] properties)
+        {
+            var mappedProperties = GetObjectPropertyMap(properties);
+
+            var extraDataExp = Expression.Variable(typeof(GenericData), "extra");
+            var targetExp = Expression.Parameter(typeof(T), "target");
+            var jsonPropertiesExp = Expression.Parameter(typeof(IEnumerable<JProperty>), "jProps");
+            var jsonPropertyType = typeof(JProperty);
+
+            var forEachExp = ReflectionHelper.CreateForEach(
+                    jsonPropertiesExp,
+                    currentExp =>
+                    {
+                        var currentValueExp = Expression.Property(currentExp, jsonPropertyType.GetPropertyPortable(nameof(JProperty.Value)));
+                        var currentNameExp = Expression.Property(currentExp, jsonPropertyType.GetPropertyPortable(nameof(JProperty.Name)));
+
+                        var defaultCase = Expression.Call(
+                                extraDataExp,
+                                typeof(GenericData).GetMethodPortable(nameof(GenericData.SetData)).MakeGenericMethod(typeof(JToken)),
+                                currentNameExp,
+                                currentValueExp);
+
+                        var cases = mappedProperties
+                                .Select(pair =>
+                                {
+                                    var currentValueToObject = Expression.Call(
+                                       currentValueExp,
+                                       jsonPropertyType
+                                           .GetMethodPortable(nameof(JProperty.ToObject), Type.EmptyTypes)
+                                           .MakeGenericMethod(pair.Value.PropertyType));
+
+                                    return Expression.SwitchCase(
+                                        Expression.Assign(Expression.Property(targetExp, pair.Value), currentValueToObject),
+                                        Expression.Constant(pair.Key));
+
+                                })
+                                .ToArray();
+
+                        var result = Expression.Switch(typeof(void), currentNameExp, defaultCase, null, cases);
+
+                        return result;
+                    });
+
+            var finalExpression = Expression.Lambda<Builder<T>>(
+                Expression.Block(
+                    new[] { extraDataExp },
+                    Expression.Assign(extraDataExp, Expression.New(typeof(GenericData))),
+                    forEachExp,
+                    extraDataExp),
+                targetExp,
+                jsonPropertiesExp
+                );
+
+            return finalExpression.Compile();
+        }
+
+        private static Dictionary<string, PropertyInfo> GetObjectPropertyMap(PropertyInfo[] properties)
+        {
+            var mappedProperties = new Dictionary<string, PropertyInfo>();
+
+            foreach (var property in properties)
+            {
+                var ignore = false;
+                var propertyName = property.Name;
+                var attributes = property.GetCustomAttributes(true);
+
+                foreach (var attribute in attributes)
+                {
+                    if (attribute is JsonPropertyAttribute propertyAttribute)
+                    {
+                        propertyName = propertyAttribute.PropertyName;
+                        break;
+                    }
+                    else if (attribute is JsonIgnoreAttribute ignoreAttr)
+                    {
+                        ignore = true;
+                        break;
+                    }
+                }
+
+                if (ignore || mappedProperties.ContainsKey(propertyName))
+                    continue;
+
+                mappedProperties.Add(propertyName, property);
+            }
+
+            return mappedProperties;
+        }
+
+        internal static GenericData FromJObjectOld<T>(T obj, JObject json)
+        {
+            var properties = typeof(T).GetPropertiesPortable();
+
+            var objProps = new Dictionary<string, PropertyInfo>();
+            var extra = new GenericData();
 
             foreach (var prop in properties)
             {
@@ -76,6 +196,102 @@ namespace StreamChat
                     extra.SetData(jsonProp.Name, jsonProp.Value);
             }
             return extra;
+        }
+    }
+
+    internal static class ReflectionHelper
+    {
+        public static PropertyInfo GetPropertyPortable(this Type type, string propName)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetProperty(propName);
+        }
+
+        public static PropertyInfo[] GetPropertiesPortable(this Type type)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetProperties();
+        }
+
+        public static MethodInfo GetMethodPortable(this Type type, string methodName)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetMethod(methodName);
+        }
+
+        public static MethodInfo GetMethodPortable(this Type type, string methodName, params Type[] types)
+        {
+            types = types ?? (new Type[0]);
+
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetMethod(methodName, types);
+        }
+
+        public static Type[] GetInterfacesPortable(this Type type)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetInterfaces();
+        }
+
+        public static Expression CreateForEach(ParameterExpression enumerableExp, Func<ParameterExpression, Expression> bodyGenerator)
+        {
+            var breakLabel = Expression.Label("ForeachBreak");
+            var getEnumeratorMethod = enumerableExp.Type.GetMethodPortable(nameof(IEnumerable.GetEnumerator));
+            var enumeratorType = getEnumeratorMethod.ReturnType;
+            var enumeratorExp = Expression.Parameter(enumeratorType, "enumerator");
+            var moveNextMethod = typeof(IEnumerator).GetMethodPortable(nameof(IEnumerator.MoveNext));
+            var currentProperty = enumeratorType.GetPropertyPortable(nameof(IEnumerator.Current));
+            var currentExpression = Expression.Parameter(currentProperty.PropertyType, "current");
+
+            Expression loopBlock = Expression.Loop(
+                        Expression.IfThenElse(
+                            Expression.Call(enumeratorExp, moveNextMethod),
+                            Expression.Block(
+                                new[] { currentExpression },
+                                Expression.Assign(
+                                    currentExpression,
+                                    Expression.Property(enumeratorExp, currentProperty)),
+                                bodyGenerator(currentExpression)
+                                ),
+                            Expression.Break(breakLabel)));
+
+            var diposableType = typeof(IDisposable);
+
+            if (enumeratorType.GetInterfacesPortable().Contains(diposableType))
+            {
+                var disposeMethod = diposableType.GetMethodPortable(nameof(IDisposable.Dispose));
+
+                loopBlock = Expression.TryFinally(loopBlock, Expression.Call(Expression.Convert(enumerableExp, diposableType), disposeMethod));
+            }
+
+            var res = Expression.Block(
+                    new[]
+                    {
+                        enumeratorExp
+                    },
+                    Expression.Assign(
+                        enumeratorExp,
+                        Expression.Call(enumerableExp, getEnumeratorMethod)),
+                    loopBlock,
+                    Expression.Label(breakLabel)
+                );
+
+            return res;
         }
     }
 }

--- a/src/stream-chat-net/JSONHelpers.cs
+++ b/src/stream-chat-net/JSONHelpers.cs
@@ -18,6 +18,12 @@ namespace StreamChat
         internal static GenericData FromJObject<T>(T obj, JObject json)
             where T : class
         {
+            if (obj is null)
+                throw new ArgumentNullException(nameof(obj));
+
+            if (json is null)
+                throw new ArgumentNullException(nameof(json));
+
             var jProps = json.Properties();
             
             var builder = (Builder<T>)CachedBuilders.GetOrAdd(typeof(T), _ => ConstructBuilder<T>());

--- a/src/stream-chat-net/ReflectionHelper.cs
+++ b/src/stream-chat-net/ReflectionHelper.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Linq.Expressions;
+using System.Collections;
+
+namespace StreamChat
+{
+    internal static class ReflectionHelper
+    {
+        public static PropertyInfo GetPropertyPortable(this Type type, string propName)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetProperty(propName);
+        }
+
+        public static PropertyInfo[] GetPropertiesPortable(this Type type)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetProperties();
+        }
+
+        public static MethodInfo GetMethodPortable(this Type type, string methodName)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetMethod(methodName);
+        }
+
+        public static MethodInfo GetMethodPortable(this Type type, string methodName, params Type[] types)
+        {
+            types = types ?? (new Type[0]);
+
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetMethod(methodName, types);
+        }
+
+        public static Type[] GetInterfacesPortable(this Type type)
+        {
+            return type
+#if NETSTANDARD1_6
+                .GetTypeInfo()
+#endif
+                .GetInterfaces();
+        }
+
+        public static Expression CreateForEach(ParameterExpression enumerableExp, Func<ParameterExpression, Expression> bodyGenerator)
+        {
+            var breakLabel = Expression.Label("ForeachBreak");
+            var getEnumeratorMethod = enumerableExp.Type.GetMethodPortable(nameof(IEnumerable.GetEnumerator));
+            var enumeratorType = getEnumeratorMethod.ReturnType;
+            var enumeratorExp = Expression.Parameter(enumeratorType, "enumerator");
+            var moveNextMethod = typeof(IEnumerator).GetMethodPortable(nameof(IEnumerator.MoveNext));
+            var currentProperty = enumeratorType.GetPropertyPortable(nameof(IEnumerator.Current));
+            var currentExpression = Expression.Parameter(currentProperty.PropertyType, "current");
+
+            Expression loopBlock = Expression.Loop(
+                        Expression.IfThenElse(
+                            Expression.Call(enumeratorExp, moveNextMethod),
+                            Expression.Block(
+                                new[] { currentExpression },
+                                Expression.Assign(
+                                    currentExpression,
+                                    Expression.Property(enumeratorExp, currentProperty)),
+                                bodyGenerator(currentExpression)
+                                ),
+                            Expression.Break(breakLabel)));
+
+            var diposableType = typeof(IDisposable);
+
+            if (enumeratorType.GetInterfacesPortable().Contains(diposableType))
+            {
+                var disposeMethod = diposableType.GetMethodPortable(nameof(IDisposable.Dispose));
+
+                loopBlock = Expression.TryFinally(loopBlock, Expression.Call(Expression.Convert(enumerableExp, diposableType), disposeMethod));
+            }
+
+            var res = Expression.Block(
+                    new[]
+                    {
+                        enumeratorExp
+                    },
+                    Expression.Assign(
+                        enumeratorExp,
+                        Expression.Call(enumerableExp, getEnumeratorMethod)),
+                    loopBlock,
+                    Expression.Label(breakLabel)
+                );
+
+            return res;
+        }
+    }
+}

--- a/src/stream-chat-net/stream-chat-net.csproj
+++ b/src/stream-chat-net/stream-chat-net.csproj
@@ -23,6 +23,11 @@
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>stream-chat-net-test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45'">


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This change reduces the reliance on reflection by the JSON deserialization method, FromJObject. This is done by compiling and caching type specific delegates from expression trees, composed on demand. This change effects an initial performance cost for the delegate compilation, but also a significant performance improvement for the subsequent delegate execution as compared to the original approach. 