### PR TITLE
Use single HttpClient, plus code simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,17 @@ using StreamChat;
 ### Initialize client
 
 ```c#
-// snip
+// client instantiation
 
 var client = new Client("API KEY", "API SECRET");
 
+// or if you want to use your own HttpClient
+
+var client = new Client("API KEY", "API SECRET", httpClient);
+
 ```
+
+> :bulb: It is strongly recommended to use the same client for the lifetime of your application.
 
 ### Generate a token for clientside use
 
@@ -268,3 +274,10 @@ if (complete)
     Console.WriteLine(resp.Result.URL);
 }
 ```
+
+## We are hiring!
+
+We've recently closed a [$38 million Series B funding round](https://techcrunch.com/2021/03/04/stream-raises-38m-as-its-chat-and-activity-feed-apis-power-communications-for-1b-users/) and we keep actively growing.
+Our APIs are used by more than a billion end-users, and you'll have a chance to make a huge impact on the product within a team of the strongest engineers all over the world.
+
+Check out our current openings and apply via [Stream's website](https://getstream.io/team/#jobs).

--- a/src/stream-chat-net-test/ChannelTests.cs
+++ b/src/stream-chat-net-test/ChannelTests.cs
@@ -19,7 +19,7 @@ namespace StreamChatTests
         [SetUp]
         public void Setup()
         {
-            _client = Credentials.Instance.Client;
+            _client = TestClientFactory.GetClient();
         }
 
         [Test]

--- a/src/stream-chat-net-test/ClientTests.cs
+++ b/src/stream-chat-net-test/ClientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -17,7 +18,7 @@ namespace StreamChatTests
         [SetUp]
         public void Setup()
         {
-            _client = Credentials.Instance.Client;
+            _client = TestClientFactory.GetClient();
         }
 
         [Test]
@@ -38,6 +39,14 @@ namespace StreamChatTests
             Assert.NotNull(appSettings.ChannelConfigs);
             Assert.True(appSettings.ChannelConfigs.ContainsKey("messaging"));
             Assert.True(appSettings.MultiTenantEnabled);
+        }
+
+        [Test]
+        public async Task TestCustomHttpClient()
+        {
+            var client = TestClientFactory.GetClient(new HttpClient());
+            var resp = await client.GetRateLimits(new GetRateLimitsOptions());
+            Assert.NotNull(resp);
         }
 
         [Test]

--- a/src/stream-chat-net-test/UserTests.cs
+++ b/src/stream-chat-net-test/UserTests.cs
@@ -19,7 +19,7 @@ namespace StreamChatTests
         [SetUp]
         public void Setup()
         {
-            _client = Credentials.Instance.Client;
+            _client = TestClientFactory.GetClient();
             _endpoint = _client.Users;
         }
 

--- a/src/stream-chat-net-test/Utils.cs
+++ b/src/stream-chat-net-test/Utils.cs
@@ -1,28 +1,27 @@
 using System;
+using System.Net.Http;
 
 namespace StreamChatTests
 {
-    public class Credentials
+    public static class TestClientFactory
     {
-        public static Credentials Instance = new Credentials();
+        private static string _apiKey = Environment.GetEnvironmentVariable("STREAM_API_KEY");
+        private static string _apiSecret = Environment.GetEnvironmentVariable("STREAM_API_SECRET");
+        private static StreamChat.Client _defaultClient = new StreamChat.Client(_apiKey, _apiSecret,
+                new StreamChat.ClientOptions
+                {
+                    Timeout = 10000
+                });
 
-        public StreamChat.IClient Client
+        public static StreamChat.IClient GetClient()
         {
-            get
-            {
-                return _client;
-            }
+            return _defaultClient;
         }
 
-
-        private readonly StreamChat.Client _client;
-
-        internal Credentials()
+        public static StreamChat.IClient GetClient(HttpClient httpClient)
         {
-            var apiKey = Environment.GetEnvironmentVariable("STREAM_API_KEY");
-            var apiSecret = Environment.GetEnvironmentVariable("STREAM_API_SECRET");
-            _client = new StreamChat.Client(apiKey, apiSecret,
-                new StreamChat.ClientOptions()
+            return new StreamChat.Client(_apiKey, _apiSecret, httpClient,
+                new StreamChat.ClientOptions
                 {
                     Timeout = 10000
                 });

--- a/src/stream-chat-net/Client.cs
+++ b/src/stream-chat-net/Client.cs
@@ -1,48 +1,66 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamChat.Rest;
+using HttpMethod = StreamChat.Rest.HttpMethod;
 
 namespace StreamChat
 {
     public class Client : IClient
     {
-        static readonly string Version = "0.22.0";
-        internal readonly Uri BaseUrl = new Uri("https://chat.stream-io-api.com");
-
-        internal static readonly object JWTHeader = new
+        private static readonly string Version = "0.22.0";
+        private readonly Uri BaseUrl = new Uri("https://chat.stream-io-api.com");
+        private static readonly HttpClient DefaultHttpClient = new HttpClient();
+        private static readonly object JWTHeader = new
         {
             typ = "JWT",
             alg = "HS256"
         };
-        static readonly DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private readonly ClientOptions _options;
+        private readonly RestClient _client;
+        private readonly string _apiSecret;
+        private readonly string _apiKey;
+        private readonly string _token;
 
-        readonly ClientOptions _options;
-        readonly RestClient _client;
-        readonly string _apiSecret;
-        readonly string _apiKey;
-        readonly string _token;
+        public Client(string apiKey, string apiSecret) : this(null, null, apiKey, apiSecret)
+        {
+        }
 
-        public Client(string apiKey, string apiSecret, ClientOptions opts = null)
+        public Client(string apiKey, string apiSecret, ClientOptions opts) : this(opts, null, apiKey, apiSecret)
+        {
+        }
+
+        public Client(string apiKey, string apiSecret, HttpClient httpClient) : this(null, httpClient, apiKey, apiSecret)
+        {
+        }
+
+        public Client(string apiKey, string apiSecret, HttpClient httpClient, ClientOptions opts) : this(opts, httpClient, apiKey, apiSecret)
+        {
+        }
+
+        private Client(ClientOptions opts, HttpClient httpClient, string apiKey, string apiSecret)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
-                throw new ArgumentNullException("apiKey", "Must have an apiKey");
+                throw new ArgumentNullException(nameof(apiKey), "Must have an apiKey");
             if (string.IsNullOrWhiteSpace(apiSecret))
-                throw new ArgumentNullException("apiSecret", "Must have an apiSecret");
+                throw new ArgumentNullException(nameof(apiSecret), "Must have an apiSecret");
+
             _apiKey = apiKey;
             _apiSecret = apiSecret;
             _options = opts ?? ClientOptions.Default;
-            _client = new RestClient(BaseUrl, TimeSpan.FromMilliseconds(_options.Timeout));
-            var payload = new
+            httpClient = httpClient ?? DefaultHttpClient;
+            _client = new RestClient(httpClient, BaseUrl, TimeSpan.FromMilliseconds(_options.Timeout));
+            var payload = new Dictionary<string, object>
             {
-                server = true
+                {"server",  true}
             };
-            _token = this.JWToken(payload);
+            _token = this.GenerateJwt(payload);
         }
 
         public IUsers Users
@@ -63,7 +81,7 @@ namespace StreamChat
             {
                 payload["exp"] = (Int32)(expiration.Value.ToUniversalTime().Subtract(epoch).TotalSeconds);
             }
-            return this.JWToken(payload);
+            return this.GenerateJwt(payload);
         }
 
         public async Task UpdateAppSettings(AppSettings settings)
@@ -429,7 +447,7 @@ namespace StreamChat
             return _client.Execute(request);
         }
 
-        public string JWToken(object payload)
+        private string GenerateJwt(object payload)
         {
             var segments = new List<string>();
 

--- a/src/stream-chat-net/Rest/HttpMethod.cs
+++ b/src/stream-chat-net/Rest/HttpMethod.cs
@@ -1,4 +1,6 @@
-﻿namespace StreamChat.Rest
+﻿using System;
+
+namespace StreamChat.Rest
 {
     public enum HttpMethod
     {
@@ -7,5 +9,27 @@
         DELETE,
         PUT,
         PATCH
+    }
+
+    public static class HttpMethodExtensions
+    {
+        public static System.Net.Http.HttpMethod ToDotnetHttpMethod(this HttpMethod method)
+        {
+            switch (method)
+            {
+                case HttpMethod.GET:
+                    return System.Net.Http.HttpMethod.Get;
+                case HttpMethod.POST:
+                    return System.Net.Http.HttpMethod.Post;
+                case HttpMethod.DELETE:
+                    return System.Net.Http.HttpMethod.Delete;
+                case HttpMethod.PUT:
+                    return System.Net.Http.HttpMethod.Put;
+                case HttpMethod.PATCH:
+                    return new System.Net.Http.HttpMethod("PATCH");
+                default:
+                    throw new NotImplementedException(method.ToString());
+            }
+        }
     }
 }

--- a/src/stream-chat-net/Rest/RestResponse.cs
+++ b/src/stream-chat-net/Rest/RestResponse.cs
@@ -25,7 +25,10 @@ namespace StreamChat.Rest
                 StatusCode = message.StatusCode
             };
 
-            response.Content = await message.Content.ReadAsStringAsync();
+            using(message)
+            {
+                response.Content = await message.Content.ReadAsStringAsync();
+            }    
 
             return response;
         }


### PR DESCRIPTION
This pull requests contains a semi-major refactor where we use a single HttpClient instead of keep re-creating a new one.

- Created multiple different constructors to `Client`. If it was a private a repository, I wouldn't bother with it, but for public libraries, it's just a nice touch to not have nullable parameters
- Everytime you instantiate a HttpClient, it creates a new socket. Yes, it was disposed properly, but it's still an overhead to create and close a new socket every time you invoke an API. It is Microsoft's recommendation to re-use the same client. I highlighted this in the README as well. See [here](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-5.0#remarks). Actually, this might be quite a decent performance improvement.
- Added ability to pass in your own `HttpClient`. Some people use proxies, some other people likes to attach their own handlers (for logging purposes, for example), so it's more comfortable for them. Additionally, it's easier to unit test the Client if we pass in a mocked `HttpClient`. Actually, it's impossible otherwise. 😬
- Because of refactoring `HttpClient`, we needed to refactor Timeout handling a little bit as well using `CancellationToken`s.
- Disposing `HttpResponseMessage` in `RestResponse`
- Refactored the test client factory. I actually named it `TestClientFactory` instead of Credentials since it returns a test client, not a credential. Also did some minor refactors there so it's a bit easier. Did most of this because I needed a way to test a custom HttpClient.