### PR TITLE
ci: fix gh action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet pack --configuration Release ./src
 
       - name: Publish the package
-        run: dotnet nuget push --api-key ${{ secrets.NUGET_API_KEY } ./src/stream-chat-net/bin/Release/*.nupkg
+        run: dotnet nuget push --api-key ${{ secrets.NUGET_API_KEY }} ./src/stream-chat-net/bin/Release/*.nupkg
 
       - name: Create release on GitHub
         uses: actions/create-release@v1


### PR DESCRIPTION
Fixes the following issue:

```
The workflow is not valid. .github/workflows/release.yaml (Line: 33, Col: 14): The expression is not closed. An unescaped ${{ sequence was found, but the closing }} sequence was not found.
```