### PR TITLE
ci: fix globbing in dotnet push command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet pack --configuration Release ./src
 
       - name: Publish the package
-        run: dotnet nuget push --api-key ${{ secrets.NUGET_API_KEY }} ./src/stream-chat-net/bin/Release/*.nupkg
+        run: dotnet nuget push "./src/stream-chat-net/bin/Release/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
 
       - name: Create release on GitHub
         uses: actions/create-release@v1


### PR DESCRIPTION
Fixes two issues.
- Enclosing quotes are needed when globbing
- Specifying source


```
The enclosing quotes are required for shells such as bash that perform file globbing. For more information, see NuGet/Home#4393.
```

```
Starting with NuGet 3.4.2, this is a mandatory parameter unless the NuGet config file specifies a DefaultPushSource value. For more information, see Configuring NuGet behavior.
```