### PR TITLE
ci: fix logic for triggering publish

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ferhatelmas @miagilepner @driver-devel @peterdeme
+* @ferhatelmas @peterdeme

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,14 @@
 name: Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
 
 jobs:
   Release:
-    if: "${{ startsWith(github.event.head_commit.message, 'chore(release)') }}"
+    if: github.event.pull_request.merged && startsWith(github.head_ref, 'release-')
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: "true"
@@ -22,9 +23,9 @@ jobs:
             const get_change_log_diff = require('./scripts/get_changelog_diff.js')
             core.exportVariable('CHANGELOG', get_change_log_diff())
 
-            // Getting the release version from the commit message
-            // Commit message looks like this: chore(release): 1.0.0
-            const version = context.payload.head_commit.message.split(' ')[1]
+            // Getting the release version from the PR source branch
+            // Source branch looks like this: release-1.0.0
+            const version = context.payload.pull_request.head.ref.split('-')[1]
             core.exportVariable('VERSION', version)
   
       - name: Setup dotnet


### PR DESCRIPTION
Fixing the logic for triggering release build. Now it'll trigger once a PR is merged and closed.

We'll get the release version from the PR source branch name which looks like this: `release-1.2.3`