### PR TITLE
feat: add options to truncate

### DIFF
--- a/src/stream-chat-net-test/ChannelTests.cs
+++ b/src/stream-chat-net-test/ChannelTests.cs
@@ -665,14 +665,32 @@ namespace StreamChatTests
             };
             var msg3 = await channel.SendMessage(inMsg, user3.ID);
 
+            await EnsureChannelMessageCount(channel, messageCount: 3);
+
+            // Truncate without options
+            var response = await channel.Truncate();
+            await EnsureChannelMessageCount(channel, messageCount: 0);
+
+            // Truncate with options
+            await channel.SendMessage(inMsg, user3.ID);
+            await EnsureChannelMessageCount(channel, messageCount: 1);
+
+            await channel.Truncate(new TruncateOptions
+            {
+                SkipPush = true,
+                Message = new MessageInput
+                {
+                    Text = "This channel is getting truncated",
+                    User = new User { ID = user1.ID },
+                },
+            });
+            await EnsureChannelMessageCount(channel, messageCount: 1);
+        }
+
+        private static async Task EnsureChannelMessageCount(IChannel channel, int messageCount)
+        {
             var chanState = await channel.Query(new ChannelQueryParams(false, true));
-            Assert.AreEqual(3, chanState.Messages.Count);
-
-            await channel.Truncate();
-
-            chanState = await channel.Query(new ChannelQueryParams(false, true));
-
-            Assert.AreEqual(0, chanState.Messages.Count);
+            Assert.AreEqual(messageCount, chanState.Messages.Count);
         }
 
         [Test]

--- a/src/stream-chat-net/Channel.cs
+++ b/src/stream-chat-net/Channel.cs
@@ -224,7 +224,7 @@ namespace StreamChat
         public async Task<PartialUpdateChannelResponse> PartialUpdate(PartialUpdateChannelRequest partialUpdateChannelRequest)
         {
             var request = this._client.BuildAppRequest(this.Endpoint, HttpMethod.PATCH);
-            request.SetJsonBody(JsonConvert.SerializeObject(partialUpdateChannelRequest));
+            request.SetJsonBody(partialUpdateChannelRequest.ToJObject().ToString());
 
             var response = await this._client.MakeRequest(request);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
@@ -252,12 +252,26 @@ namespace StreamChat
                 throw StreamChatException.FromResponse(response);
         }
 
-        public async Task Truncate()
+        public async Task<TruncateResponse> Truncate()
+        {
+            return await Truncate(null);
+        }
+
+        public async Task<TruncateResponse> Truncate(TruncateOptions truncateOptions)
         {
             var request = this._client.BuildAppRequest(this.Endpoint + "/truncate", HttpMethod.POST);
+            if (truncateOptions != null)
+            {
+                request.SetJsonBody(truncateOptions.ToJObject().ToString());
+            }
+            
             var response = await this._client.MakeRequest(request);
-            if (response.StatusCode != System.Net.HttpStatusCode.Created)
-                throw StreamChatException.FromResponse(response);
+            if (response.StatusCode == System.Net.HttpStatusCode.Created)
+            {
+                var respObj = JObject.Parse(response.Content);
+                return TruncateResponse.FromJObject(respObj);
+            }
+            throw StreamChatException.FromResponse(response);
         }
 
         public async Task AddMembers(IEnumerable<string> userIDs, MessageInput msg = null)

--- a/src/stream-chat-net/ChannelObject.cs
+++ b/src/stream-chat-net/ChannelObject.cs
@@ -173,6 +173,14 @@ namespace StreamChat
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "unset")]
         public IEnumerable<string> Unset { get; set; }
+
+        internal JObject ToJObject()
+        {
+            var root = JObject.FromObject(this);
+            if (this.User != null)
+                root.Add("user", this.User.ToJObject());
+            return root;
+        }
     }
 
     public class PartialUpdateChannelResponse
@@ -203,6 +211,53 @@ namespace StreamChat
                 }
                 result.Members = members;
             }
+
+            return result;
+        }
+    }
+
+    public class TruncateOptions
+    {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "hard_delete")]
+        public bool? HardDelete { get; set; }
+
+        [JsonIgnore]
+        public MessageInput Message { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "skip_push")]
+        public bool? SkipPush { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "truncated_at")]
+        public DateTime? TruncatedAt { get; set; }
+
+        internal JObject ToJObject()
+        {
+            var root = JObject.FromObject(this);
+            if (this.Message != null)
+                root.Add("message", this.Message.ToJObject());
+            return root;
+        }
+    }
+
+    public class TruncateResponse
+    {
+        public string Duration { get; set; }
+        public Message Message { get; set; }
+        public ChannelObjectWithInfo Channel { get; set; }
+
+        internal static TruncateResponse FromJObject(JObject jObj)
+        {
+            var result = new TruncateResponse();
+
+            var data = JsonHelpers.FromJObject(result, jObj);
+            var msgObj = data.GetData<JObject>("message");
+            if (msgObj != null)
+                result.Message = Message.FromJObject(msgObj);
+            var chanObj = data.GetData<JObject>("channel");
+            if (chanObj != null)
+                result.Channel = ChannelObjectWithInfo.FromJObject(chanObj);
+            result.Duration = data.GetData<string>("duration");
 
             return result;
         }

--- a/src/stream-chat-net/IChannel.cs
+++ b/src/stream-chat-net/IChannel.cs
@@ -25,7 +25,8 @@ namespace StreamChat
         Task<UpdateChannelResponse> Update(GenericData customData, MessageInput msg = null, bool skipPush = false);
         Task<PartialUpdateChannelResponse> PartialUpdate(PartialUpdateChannelRequest partialUpdateChannelRequest);
         Task Delete();
-        Task Truncate();
+        Task<TruncateResponse> Truncate();
+        Task<TruncateResponse> Truncate(TruncateOptions truncateOptions);
 
         Task AddMembers(IEnumerable<string> userIDs, MessageInput msg = null);
         Task RemoveMembers(IEnumerable<string> userIDs, MessageInput msg = null);

--- a/src/stream-chat-net/MessageInput.cs
+++ b/src/stream-chat-net/MessageInput.cs
@@ -27,7 +27,7 @@ namespace StreamChat
         public string ParentID { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "shown_in_channel")]
-        public bool ShownInChannel { get; set; }
+        public bool? ShownInChannel { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "created_at")]
         public DateTime? CreatedAt { get; set; }
@@ -39,7 +39,7 @@ namespace StreamChat
         public List<string> MentionedUsers { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "silent")]
-        public bool Silent { get; set; }
+        public bool? Silent { get; set; }
 
         public MessageInput() { }
 


### PR DESCRIPTION
Adding options for truncating a channel.
Question: how can I make sure the truncation message was received in the channel? The channel message count is zero.