### PR TITLE
ci: tooling improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: CI
 
 on: [pull_request]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   basic:
     name: Run tests on ${{ matrix.os }}
@@ -24,15 +28,18 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: |
-            5.0.x
-            3.1.x
+          dotnet-version: 5.0.x
+
+      - name: Dependency cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/*.csproj') }}
 
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: dotnet restore ./src
-
-      - name: Build
-        run: dotnet build --configuration Release --no-restore ./src
 
       - name: Run tests
         run: dotnet test ./src/stream-chat-net-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,14 +33,13 @@ jobs:
         with:
           dotnet-version: "5.0.x"
 
-      - name: Build
-        run: dotnet build --configuration Release ./src
-
       - name: Create the package
         run: dotnet pack --configuration Release ./src
 
-      - name: Publish the package
-        run: dotnet nuget push "./src/stream-chat-net/bin/Release/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      - name: Publish the package & symbols
+        run: |
+          dotnet nuget push "./src/stream-chat-net/bin/Release/*.nupkg"  -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push "./src/stream-chat-net/bin/Release/*.snupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
 
       - name: Create release on GitHub
         uses: ncipollo/release-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.ldf
 *.gitattributes
 *.log
+.DS_Store
 Thumbs.db
 .idea/
 *packages/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# :recycle: Contributing
+
+We welcome code changes that improve this library or fix a problem, please make sure to follow all best practices and add tests if applicable before submitting a Pull Request on Github. We are very happy to merge your code in the official repository. Make sure to sign our [Contributor License Agreement (CLA)](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) first. See our license file for more details.
+
+## Getting started
+
+### Restore dependencies and build
+
+Most IDEs automatically prompt you to restore the dependencies but if not, use this command:
+
+```shell
+$ dotnet restore ./src
+```
+
+Building:
+
+```shell
+$ dotnet build ./src
+```
+
+### Run tests
+
+The tests we have are full fledged integration tests, meaning they will actually reach out to a Stream app. Hence the tests require at least two environment variables: `STREAM_API_KEY` and `STREAM_API_SECRET`.
+
+To have these env vars available for the test running, you need to set up a `.runsettings` file in the root of the project (don't worry, it's gitignored).
+
+> :bulb Microsoft has a super detailed [documentation](https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file) about .runsettings file.
+  
+It needs to look like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <STREAM_API_KEY>api_key_here</STREAM_API_KEY>
+      <STREAM_API_SECRET>secret_key_here</STREAM_API_SECRET>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>
+```
+
+In CLI:
+```shell
+$ dotnet test -s .runsettings ./src/stream-chat-net-test
+```
+
+Go to the next section to see how to use it in IDEs.
+
+## Recommended tools for day-to-day development
+
+### VS Code
+
+For VS Code, the recommended extensions are:
+- [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) by Microsoft
+- [.NET Core Test Explorer](https://marketplace.visualstudio.com/items?itemName=formulahendry.dotnet-test-explorer) by Jun Huan
+
+Recommended settings (`.vscode/settings.json`):
+```json
+{
+    "omnisharp.testRunSettings": ".runsettings",
+    "dotnet-test-explorer.testProjectPath": "./src/stream-chat-net-test",
+}
+```
+
+### Visual Studio
+
+Follow [Microsoft's documentation](https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2022#specify-a-run-settings-file-in-the-ide) on how to set up `.runsettings` file.
+
+### Rider
+
+Follow [Jetbrain's documentation](https://www.jetbrains.com/help/rider/Reference__Options__Tools__Unit_Testing__MSTest.html) on how to set up `.runsettings` file.

--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ if (complete)
 
 ## Contributing
 
-## Contributing
-
 We welcome code changes that improve this library or fix a problem, please make sure to follow all best practices and add tests if applicable before submitting a Pull Request on Github. We are very happy to merge your code in the official repository. Make sure to sign our [Contributor License Agreement (CLA)](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) first. See our license file for more details.
+
+Head over to [CONTRIBUTING.md](./CONTRIBUTING.md) for some development tips.
 
 ## We are hiring!
 

--- a/src/stream-chat-net-test/stream-chat-net-test.csproj
+++ b/src/stream-chat-net-test/stream-chat-net-test.csproj
@@ -1,18 +1,18 @@
-﻿<Project ToolsVersion="16.5" Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Configuration">
     <DefineConstants>TRACE;DEBUG;NETCORE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/stream-chat-net/Rest/RestClient.cs
+++ b/src/stream-chat-net/Rest/RestClient.cs
@@ -27,7 +27,7 @@ namespace StreamChat.Rest
             _httpClient = httpClient;
             _baseUrl = baseUrl;
             Timeout = timeout;
-#if NET45
+#if OLD_TLS_HANDLING
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 #endif
         }

--- a/src/stream-chat-net/stream-chat-net.csproj
+++ b/src/stream-chat-net/stream-chat-net.csproj
@@ -1,58 +1,40 @@
-﻿<Project ToolsVersion="16.5" Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Configuration">
     <DefineConstants>TRACE;DEBUG;NETCORE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>net45;net461;net472;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;net48;netstandard1.6;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>stream-chat-net</PackageId>
     <Version>0.25.0</Version>
-    <PackageVersion>0.25.0</PackageVersion>
     <Authors>Getstream.io</Authors>
     <Description>Chat client for getstream.io.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright 2021</Copyright>
+    <RepositoryUrl>https://github.com/GetStream/stream-chat-net</RepositoryUrl>
     <PackageProjectUrl>https://github.com/GetStream/stream-chat-net</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/GetStream/stream-chat-net/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReleaseNotes>$([System.Environment]::GetEnvironmentVariable("CHANGELOG"))</PackageReleaseNotes>
     <PackageTags>getstreamio</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <Company>Stream</Company>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>NET45</DefineConstants>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
+      <None Include="../../LICENSE" Pack="true" PackagePath=""/>
+  </ItemGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'net45' OR $(TargetFramework) == 'net46'">
+    <DefineConstants>OLD_TLS_HANDLING</DefineConstants>
+  </PropertyGroup>
+    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Net.Http" />
-		<Reference Include="System.Xml.Linq" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System.Data" />
-		<Reference Include="System.Xml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Improvements & bug fixes

- Introduced concurrency for CI. Why run 2 builds at the same time for the exact same branch? 🙂
- Introduced dependency caching. This makes the builds faster. We can win more than a minute on Windows. Much less on OSX/Linux though (17 seconds).
  - As soon as we update to .NET 6, I'll introduce a package locking feature as well. Currently it has a small bug on .NET 5 on Windows platform: https://github.com/NuGet/Home/issues/10901
  - Note: as of today (dec 12), the caching build step is broken due to a general GitHub outage. Should be fixed next week: https://github.com/actions/cache/issues/698
- Removed build step. `dotnet test` command actually builds the project, so no need to have it.
- Introduced symbol publishing, plus SourceLink. Symbol publishing makes it possible for SDK users to see the source code of our library in their IDEs, instead of just a plain `.dll` binary.
  - [SourceLink](https://github.com/dotnet/sourcelink/blob/main/README.md) is a pretty new feature introduced by Microsoft. In short: similarly to symbols, it gives you the ability to see the source code of a library. But this one actually downloads to source code from GitHub and opens it in your IDE. See [this video](https://youtu.be/rAGh8iy9YnU?t=489) (timestamped link!). Our users will **love** this!
- Added CONTRIBUTING.md file
  - Wrote a pretty comprehensive description of how to contribute to the project, including how to handle env vars.
- Test project file:
  - Removed `ToolsVersion`, not needed 
  - Target framework is 5.0 instead of 3.1. Our library is 5.0 anyway, why would we use 3.1.
  - Bumped package versions.
- Main project file:
  - Removed `ToolsVersion`, not needed
  - TargetFrameworks:
    - Deleted `netcoreapp` from the targets. This was probably a slight oversight, but netcoreapp is never needed for target frameworks. `netstandard` should be the target for libraries. Netstandard actually covers netcoreapp already. Example [here](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Newtonsoft.Json.csproj#L3) for Json.Net library.
    - Removed patch versions for classic .net framework. net45,46,47,48 is enough.
    - Added `net48` and `netstandard2.1`.
    - Ordered the TargetFrameworks in an ascending order. Just for easier reading.
  - Publishing the release notes to nuget.
  - `PackageLicenseUrl` is deprecated unfortunately. We need to include the license file in the package itself. Meh. 🤷 
  - Added new config values for symbols and sourcelink publishing
  - Added SourceLink as a dev dependency (`PrivateAssets`)
  - Removed a lot of unnecessary dependencies. Added the only necessary one (`System.Net.Http`).
  - The TLS handling thing wasn't entirely correct. It was fixed by Microsoft after .NET 4.7. So I corrected that logic.

 

## Future improvements
- Add .NET 6 to target frameworks. Question: do we even have a blocker? I thought AppVeyor is the only blocker for that.
  - Once bumped, introduce package locking mechanism. (.NET 5 has a bug.)
  - Once bumped, introduce publishing README.md with the package to have nice fancy page in Nuget. 👌 (.NET 5 has a bug with this https://github.com/NuGet/Home/issues/10791 )

And some things I didn't want to introduce in this PR, but in next ones:
- Introduce linter and code formatter.
- Add `.editorconfig`