### PR TITLE
feat: extend appsettings

### DIFF
--- a/src/stream-chat-net-test/ClientTests.cs
+++ b/src/stream-chat-net-test/ClientTests.cs
@@ -202,7 +202,7 @@ namespace StreamChatTests
                 {
                     { "foo", "new" }
                 },
-                Unset = new List<string> { "bar"},
+                Unset = new List<string> { "bar" },
             });
 
             Assert.AreEqual(msg.ID, resp.Message.ID);

--- a/src/stream-chat-net/APPSettingsWithDetails.cs
+++ b/src/stream-chat-net/APPSettingsWithDetails.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace StreamChat
 {
-    public class AppSettingsWithDetails
+    public class AppSettingsWithDetails : AppSettingsBase
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "name")]
         public string Name { get; set; }
@@ -14,9 +14,6 @@ namespace StreamChat
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "push_notifications")]
         public PushNotificationFields PushNotificationFields { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "webhook_url")]
-        public string WebhookURL { get; set; }
-
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "channel_configs")]
         public Dictionary<string, ChannelConfig> ChannelConfigs { get; set; }
 
@@ -25,18 +22,6 @@ namespace StreamChat
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "suspended_explanation")]
         public string SuspendedExplanation { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disable_auth_checks")]
-        public bool DisableAuth { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disable_permissions_checks")]
-        public bool DisablePermissions { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "async_url_enrich_enabled")]
-        public bool AsyncURLEnrichEnabled { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "multi_tenant_enabled")]
-        public bool MultiTenantEnabled { get; set; }
     }
 
     public class PushNotificationFields
@@ -46,13 +31,19 @@ namespace StreamChat
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "firebase")]
         public FirebaseFields Firebase { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "huawei")]
+        public HuaweiFields Huawei { get; set; }
     }
 
-    public class APNFields
+    public abstract class PushNotificationBase
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "enabled")]
         public bool Enabled { get; set; }
+    }
 
+    public class APNFields : PushNotificationBase
+    {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "auth_type")]
         public string AuthType { get; set; }
 
@@ -69,15 +60,16 @@ namespace StreamChat
         public string TeamID { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "key_id")]
-        public string KeyID { get; set; }  
+        public string KeyID { get; set; }
     }
 
-    public class FirebaseFields
+    public class FirebaseFields : PushNotificationBase
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "notification_template")]
         public string NotificationTemplate { get; set; }
+    }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "enabled")]
-        public bool Enabled { get; set; }
+    public class HuaweiFields : PushNotificationBase
+    {
     }
 }

--- a/src/stream-chat-net/AppSettings.cs
+++ b/src/stream-chat-net/AppSettings.cs
@@ -1,20 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace StreamChat
 {
-    public class AppSettings
+    public class FileUploadConfig
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "allowed_file_extensions")]
+        public List<string> AllowedFileExtensions { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "blocked_file_extensions")]
+        public List<string> BlockedFileExtensions { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "allowed_mime_types")]
+        public List<string> AllowedMimeTypes { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "blocked_mime_types")]
+        public List<string> BlockedMimeTypes { get; set; }
+    }
+
+    public enum PermissionVersion
+    {
+        [EnumMember(Value = "v1")]
+        V1,
+        [EnumMember(Value = "v2")]
+        V2,
+    }
+
+    public enum UniqueUsernameEnforcementPolicy
+    {
+        [EnumMember(Value = "no")]
+        No,
+        [EnumMember(Value = "app")]
+        App,
+        [EnumMember(Value = "team")]
+        Team,
+    }
+
+    public abstract class AppSettingsBase
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disable_auth_checks")]
-        public bool DisableAuth { get; set; }
+        public bool? DisableAuth { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disable_permissions_checks")]
-        public bool DisablePermissions { get; set; }
+        public bool? DisablePermissions { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "multi_tenant_enabled")]
-        public bool MultiTenantEnabled { get; set; }
+        public bool? MultiTenantEnabled { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "permission_version")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PermissionVersion? PermissionVersion { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "async_url_enrich_enabled")]
-        public bool AsyncURLEnrichEnabled { get; set; }
+        public bool? AsyncURLEnrichEnabled { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "custom_action_handler_url")]
+        public string CustomActionHandlerUrl { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "webhook_url")]
+        public string WebhookURL { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "webhook_events")]
+        public List<string> WebhookEvents { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "user_search_disallowed_roles")]
+        public List<string> UserSearchDisallowedRoles { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "before_message_send_hook_url")]
+        public string BeforeMessageSendHookUrl { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "image_moderation_labels")]
+        public List<string> ImageModerationLabels { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "image_moderation_enabled")]
+        public bool? ImageModerationEnabled { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "auto_translation_enabled")]
+        public bool? AutoTranslationEnabled { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "sqs_url")]
+        public string SqsUrl { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "sqs_key")]
+        public string SqsKey { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "sqs_secret")]
+        public string SqsSecret { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "image_upload_config")]
+        public FileUploadConfig ImageUploadConfig { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "file_upload_config")]
+        public FileUploadConfig FileUploadConfig { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "revoke_tokens_issued_before")]
+        public DateTime? RevokeTokensIssuedBefore { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "enforce_unique_usernames")]
+        public UniqueUsernameEnforcementPolicy? EnforceUniqueUsernames { get; set; }
+    }
+
+    public class AppSettings : AppSettingsBase
+    {
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "apn_config")]
         public APNConfig APNConfig { get; set; }
@@ -22,8 +112,14 @@ namespace StreamChat
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "firebase_config")]
         public FirebaseConfig FirebaseConfig { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "webhook_url")]
-        public string WebhookURL { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "huawei_config")]
+        public HuaweiConfig HuaweiConfig { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "migrate_permissions_to_v2")]
+        public bool? MigratePermissionsToV2 { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "channel_hide_members_only")]
+        public bool? ChannelHideMembersOnly { get; set; }
     }
 
     public struct APNAuthType
@@ -75,5 +171,14 @@ namespace StreamChat
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "disabled")]
         public bool Disabled { get; set; }
+    }
+
+    public class HuaweiConfig
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "secret")]
+        public string Secret { get; set; }
     }
 }

--- a/src/stream-chat-net/Client.cs
+++ b/src/stream-chat-net/Client.cs
@@ -62,7 +62,7 @@ namespace StreamChat
                 {"server",  true}
             };
             _token = this.GenerateJwt(payload);
-            var assemblyVersion =  typeof(Client).GetTypeInfo().Assembly.GetName().Version;
+            var assemblyVersion = typeof(Client).GetTypeInfo().Assembly.GetName().Version;
             Version = string.Join(".", assemblyVersion.Major, assemblyVersion.Minor, assemblyVersion.Build);
         }
 
@@ -109,7 +109,7 @@ namespace StreamChat
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 var obj = JObject.Parse(response.Content);
-                return (AppSettingsWithDetails)obj.Property("app").Value.ToObject(typeof(AppSettingsWithDetails));
+                return obj.Property("app").Value.ToObject<AppSettingsWithDetails>();
             }
 
             throw StreamChatException.FromResponse(response);
@@ -317,7 +317,7 @@ namespace StreamChat
                 {
                     Duration = respObj.Property("duration").Value.ToString(),
                     Message = Message.FromJObject(msgObj)
-                };                
+                };
             }
             throw StreamChatException.FromResponse(response);
         }

--- a/src/stream-chat-net/MessageInput.cs
+++ b/src/stream-chat-net/MessageInput.cs
@@ -14,6 +14,9 @@ namespace StreamChat
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "text")]
         public string Text { get; set; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "mml")]
+        public string Mml { get; set; }
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "html")]
         public string HTML { get; set; }
 


### PR DESCRIPTION
- Extend app settings with new settings.
- Make `bool` -> `bool?`. If we use`NullValueHandling = NullValueHandling.Ignore`, then it needs to be a reference type, otherwise it won't be null.
Similarly to Go `Boolean` vs `*Boolean`. The first is getting serialized into `false`, the second is `null`.
- Make base class for common properties