### PR TITLE
ci: fix release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,10 +36,8 @@ jobs:
       - name: Create the package
         run: dotnet pack --configuration Release ./src
 
-      - name: Publish the package & symbols
-        run: |
-          dotnet nuget push "./src/stream-chat-net/bin/Release/*.nupkg"  -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
-          dotnet nuget push "./src/stream-chat-net/bin/Release/*.snupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      - name: Publish the package
+        run: dotnet nuget push "./src/stream-chat-net/bin/Release/*.nupkg"  -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
 
       - name: Create release on GitHub
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Apparently the nupkg push will also push the symbol package as well.

This is the issue:

![image](https://user-images.githubusercontent.com/19969687/147107695-aae11f38-c7e5-4423-be04-b88012aa69fd.png)

I have tested it and the simple nupkg push will upload the symbol automatically. Here is my test:

![image](https://user-images.githubusercontent.com/19969687/147108644-c4b144ea-093b-4c5d-8637-02ee5f8dc0ae.png)
