### PR TITLE
fix: missing request api key in .NET 4.8 (#115)

### DIFF
--- a/src/Rest/RestClient.cs
+++ b/src/Rest/RestClient.cs
@@ -93,7 +93,11 @@ namespace StreamChat.Rest
 
             request.QueryParameters.ForEach(p =>
             {
-                queryStringBuilder.Append(queryStringBuilder.Length == 0 ? "?" : "&");
+                if (queryStringBuilder.Length > 0)
+                {
+                    queryStringBuilder.Append("&");
+                }
+
                 queryStringBuilder.Append($"{p.Key}={Uri.EscapeDataString(p.Value)}");
             });
 


### PR DESCRIPTION
Fixed invalid request uri for .NET 4.8. The resulting uri had double `?` due to UriBuilder.Query always prepending `?` (in .NET 6 it checks if `?` is already present)