### PR TITLE
Add EventResponse model suitable for deserializing events e.g. from webhooks

### DIFF
--- a/src/Models/Event.cs
+++ b/src/Models/Event.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace StreamChat.Models
 {
+    /// <summary>
+    /// Event model for custom event requests
+    /// </summary>
     public class Event : CustomDataBase
     {
         public string Type { get; set; }
@@ -14,6 +17,33 @@ namespace StreamChat.Models
         public ChannelRequest Channel { get; set; }
         public ChannelMember Member { get; set; }
         public UserRequest User { get; set; }
+        public string UserId { get; set; }
+        public OwnUser Me { get; set; }
+        public int? WatcherCount { get; set; }
+        public string Reason { get; set; }
+        public User CreatedBy { get; set; }
+        public bool? AutoModeration { get; set; }
+        public ModerationScore AutomoderationScores { get; set; }
+        public string ParentId { get; set; }
+        public string Team { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
+    }
+    
+    /// <summary>
+    /// Event model for received events
+    /// </summary>
+    public class EventResponse : CustomDataBase
+    {
+        public string Type { get; set; }
+        public string ConnectionId { get; set; }
+        public string Cid { get; set; }
+        public string ChannelId { get; set; }
+        public string ChannelType { get; set; }
+        public Message Message { get; set; }
+        public Reaction Reaction { get; set; }
+        public Channel Channel { get; set; }
+        public ChannelMember Member { get; set; }
+        public User User { get; set; }
         public string UserId { get; set; }
         public OwnUser Me { get; set; }
         public int? WatcherCount { get; set; }

--- a/tests/EventClientTests.cs
+++ b/tests/EventClientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using StreamChat.Models;
 
@@ -44,6 +45,48 @@ namespace StreamChatTests
             resp.Event.Type.Should().BeEquivalentTo(expectedEvent.Type);
             resp.Event.User.Id.Should().BeEquivalentTo(_user.Id);
             resp.Event.GetData<int[]>("foo")[0].Should().Be(expectedEvent.GetData<int[]>("foo")[0]);
+        }
+
+        [Test]
+        public async Task TestDeserializingReceivedEventAsync()
+        {
+            var messageDeletedEventJson = @"
+{
+  ""cid"": ""messaging:fun"",
+  ""type"": ""message.deleted"",
+  ""message"": {
+    ""id"": ""268d121f-82e0-4de1-8c8b-ef1201efd7a3"",
+    ""text"": ""new stuff"",
+    ""html"": ""<p>new stuff</p>\n"",
+    ""type"": ""deleted"",
+    ""user"": {
+      ""id"": ""76cd8430-2f91-4059-90e5-02dffb910297"",
+      ""role"": ""user"",
+      ""created_at"": ""2019-04-24T09:44:21.390868Z"",
+      ""updated_at"": ""2019-04-24T09:44:22.537305Z"",
+      ""last_active"": ""2019-04-24T09:44:22.535872Z"",
+      ""online"": false
+    },
+    ""attachments"": [],
+    ""latest_reactions"": [],
+    ""own_reactions"": [],
+    ""reaction_counts"": {},
+    ""reply_count"": 0,
+    ""created_at"": ""2019-04-24T09:44:22.57073Z"",
+    ""updated_at"": ""2019-04-24T09:44:22.717078Z"",
+    ""deleted_at"": ""2019-04-24T09:44:22.730524Z"",
+    ""mentioned_users"": []
+  },
+  ""created_at"": ""2019-04-24T09:44:22.733305Z"",
+  ""request_info"": {
+    ""type"": ""client"",
+    ""ip"": ""86.84.2.2"",
+    ""user_agent"": ""Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0"",
+    ""sdk"": ""stream-chat-react-10.11.0-stream-chat-javascript-client-browser-8.12.1""
+  }
+}";
+            
+            var deserializeObject = JsonConvert.DeserializeObject<EventResponse>(messageDeletedEventJson);
         }
 
         [Test]

--- a/tests/sample-message-deleted-event.json
+++ b/tests/sample-message-deleted-event.json
@@ -1,0 +1,34 @@
+{
+  "cid": "messaging:fun",
+  "type": "message.deleted",
+  "message": {
+    "id": "268d121f-82e0-4de1-8c8b-ef1201efd7a3",
+    "text": "new stuff",
+    "html": "<p>new stuff</p>\n",
+    "type": "regular",
+    "user": {
+      "id": "76cd8430-2f91-4059-90e5-02dffb910297",
+      "role": "user",
+      "created_at": "2019-04-24T09:44:21.390868Z",
+      "updated_at": "2019-04-24T09:44:22.537305Z",
+      "last_active": "2019-04-24T09:44:22.535872Z",
+      "online": false
+    },
+    "attachments": [],
+    "latest_reactions": [],
+    "own_reactions": [],
+    "reaction_counts": {},
+    "reply_count": 0,
+    "created_at": "2019-04-24T09:44:22.57073Z",
+    "updated_at": "2019-04-24T09:44:22.717078Z",
+    "deleted_at": "2019-04-24T09:44:22.730524Z",
+    "mentioned_users": []
+  },
+  "created_at": "2019-04-24T09:44:22.733305Z",
+  "request_info": {
+    "type": "client",
+    "ip": "86.84.2.2",
+    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0",
+    "sdk": "stream-chat-react-10.11.0-stream-chat-javascript-client-browser-8.12.1"
+  }
+}


### PR DESCRIPTION
The `Event` model was designed only to be used as a request body for the `IEventClient.SendEventAsync` endpoint. 
This PR adds the `EventResponse` that can be used when deserializing received events (e.g. from webhooks) 

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
- [ ] Commit message fits [conventional commits](https://www.conventionalcommits.org). Important for [CHANGELOG](./../CHANGELOG.md) generation.

## Description of the pull request
