### PR TITLE
fix: Fix invalid type of MessageModerationResult.UserKarma property

### DIFF
--- a/src/Models/Flag.cs
+++ b/src/Models/Flag.cs
@@ -44,7 +44,7 @@ namespace StreamChat.Models
         public string BlocklistName { get; set; }
         public Thresholds ModerationThresholds { get; set; }
         public ModerationScore AiModerationResponse { get; set; }
-        public int? UserKarma { get; set; }
+        public float? UserKarma { get; set; }
         public bool? UserBadKarma { get; set; }
         public DateTimeOffset? CreatedAt { get; set; }
         public DateTimeOffset? UpdatedAt { get; set; }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
- [ ] Commit message fits [conventional commits](https://www.conventionalcommits.org). Important for [CHANGELOG](./../CHANGELOG.md) generation.

## Description of the pull request
According to our OpenAPI spect the `UserKarma` field should be `float`:
```
        user_karma:
          format: float
          type: number
```
