### PR TITLE
Implement channel member partial update + archiving + pinning

### DIFF
--- a/src/Clients/ChannelClient.Crud.cs
+++ b/src/Clients/ChannelClient.Crud.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -8,7 +9,8 @@ namespace StreamChat.Clients
 {
     public partial class ChannelClient
     {
-        public async Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId, string createdBy, params string[] members)
+        public async Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId, string createdBy,
+            params string[] members)
             => await GetOrCreateAsync(channelType,
                 channelId,
                 new ChannelGetRequest
@@ -20,24 +22,28 @@ namespace StreamChat.Clients
                     },
                 });
 
-        public async Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId, ChannelGetRequest channelRequest)
+        public async Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId,
+            ChannelGetRequest channelRequest)
             => await ExecuteRequestAsync<ChannelGetResponse>($"channels/{channelType}/{channelId}/query",
-                    HttpMethod.POST,
-                    HttpStatusCode.Created,
-                    channelRequest);
+                HttpMethod.POST,
+                HttpStatusCode.Created,
+                channelRequest);
+
         public async Task<ChannelGetResponse> GetOrCreateAsync(string channelType, ChannelGetRequest channelRequest)
             => await ExecuteRequestAsync<ChannelGetResponse>($"channels/{channelType}/query",
-                    HttpMethod.POST,
-                    HttpStatusCode.Created,
-                    channelRequest);
+                HttpMethod.POST,
+                HttpStatusCode.Created,
+                channelRequest);
 
-        public async Task<UpdateChannelResponse> UpdateAsync(string channelType, string channelId, ChannelUpdateRequest updateRequest)
+        public async Task<UpdateChannelResponse> UpdateAsync(string channelType, string channelId,
+            ChannelUpdateRequest updateRequest)
             => await ExecuteRequestAsync<UpdateChannelResponse>($"channels/{channelType}/{channelId}",
                 HttpMethod.POST,
                 HttpStatusCode.Created,
                 updateRequest);
 
-        public async Task<PartialUpdateChannelResponse> PartialUpdateAsync(string channelType, string channelId, PartialUpdateChannelRequest partialUpdateChannelRequest)
+        public async Task<PartialUpdateChannelResponse> PartialUpdateAsync(string channelType, string channelId,
+            PartialUpdateChannelRequest partialUpdateChannelRequest)
             => await ExecuteRequestAsync<PartialUpdateChannelResponse>($"channels/{channelType}/{channelId}",
                 HttpMethod.PATCH,
                 HttpStatusCode.OK,
@@ -51,10 +57,47 @@ namespace StreamChat.Clients
         public async Task<TruncateResponse> TruncateAsync(string channelType, string channelId)
             => await TruncateAsync(channelType, channelId, null);
 
-        public async Task<TruncateResponse> TruncateAsync(string channelType, string channelId, TruncateOptions truncateOptions)
+        public async Task<TruncateResponse> TruncateAsync(string channelType, string channelId,
+            TruncateOptions truncateOptions)
             => await ExecuteRequestAsync<TruncateResponse>($"channels/{channelType}/{channelId}/truncate",
                 HttpMethod.POST,
                 HttpStatusCode.Created,
                 truncateOptions);
+
+        public Task<ChannelMemberResponse> PinAsync(string channelType, string channelId, string userId)
+            => UpdateMemberPartialAsync(channelType, channelId, new ChannelMemberPartialRequest
+            {
+                UserId = userId, Set = new Dictionary<string, object>()
+                {
+                    { "pinned", true },
+                },
+            });
+
+        public Task<ChannelMemberResponse> UnpinAsync(string channelType, string channelId, string userId)
+            => UpdateMemberPartialAsync(channelType, channelId, new ChannelMemberPartialRequest
+            {
+                UserId = userId, Set = new Dictionary<string, object>()
+                {
+                    { "pinned", false },
+                },
+            });
+
+        public Task<ChannelMemberResponse> ArchiveAsync(string channelType, string channelId, string userId)
+            => UpdateMemberPartialAsync(channelType, channelId, new ChannelMemberPartialRequest
+            {
+                UserId = userId, Set = new Dictionary<string, object>()
+                {
+                    { "archived", true },
+                },
+            });
+
+        public Task<ChannelMemberResponse> UnarchiveAsync(string channelType, string channelId, string userId)
+            => UpdateMemberPartialAsync(channelType, channelId, new ChannelMemberPartialRequest
+            {
+                UserId = userId, Set = new Dictionary<string, object>()
+                {
+                    { "archived", false },
+                },
+            });
     }
 }

--- a/src/Clients/ChannelClient.Members.cs
+++ b/src/Clients/ChannelClient.Members.cs
@@ -32,6 +32,12 @@ namespace StreamChat.Clients
                     Message = msg,
                 });
 
+        public async Task<ChannelMemberResponse> UpdateMemberPartialAsync(string channelType, string channelId, ChannelMemberPartialRequest channelMemberPartialRequest)
+            => await ExecuteRequestAsync<ChannelMemberResponse>($"channels/{channelType}/{channelId}/member/{channelMemberPartialRequest.UserId}",
+                HttpMethod.PATCH,
+                HttpStatusCode.OK,
+                channelMemberPartialRequest);
+
         public async Task<QueryMembersResponse> QueryMembersAsync(QueryMembersRequest queryMembersRequest)
             => await ExecuteRequestAsync<QueryMembersResponse>("members",
                 HttpMethod.GET,

--- a/src/Clients/IChannelClient.cs
+++ b/src/Clients/IChannelClient.cs
@@ -173,7 +173,7 @@ namespace StreamChat.Clients
         /// <summary>
         /// Update channel member partially.
         /// </summary>
-        /// <remarks>https://getstream.io/chat/docs/node/channel_member/#update-channel-members</remarks>
+        /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_member/#update-channel-members</remarks>
         Task<ChannelMemberResponse> UpdateMemberPartialAsync(string channelType, string channelId,
             ChannelMemberPartialRequest channelMemberPartialRequest);
 

--- a/src/Clients/IChannelClient.cs
+++ b/src/Clients/IChannelClient.cs
@@ -20,7 +20,8 @@ namespace StreamChat.Clients
         /// Adds members to a channel.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_members/?language=csharp</remarks>
-        Task<ApiResponse> AddMembersAsync(string channelType, string channelId, IEnumerable<string> userIds, MessageRequest msg, AddMemberOptions options);
+        Task<ApiResponse> AddMembersAsync(string channelType, string channelId, IEnumerable<string> userIds,
+            MessageRequest msg, AddMemberOptions options);
 
         /// <summary>
         /// Makes a member a moderator in a channel.
@@ -32,7 +33,8 @@ namespace StreamChat.Clients
         /// Assigns a role to a user.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/chat_permission_policies/?language=csharp</remarks>
-        Task<UpdateChannelResponse> AssignRolesAsync(string channelType, string channelId, AssignRoleRequest roleRequest);
+        Task<UpdateChannelResponse> AssignRolesAsync(string channelType, string channelId,
+            AssignRoleRequest roleRequest);
 
         /// <summary>
         /// Deletes a channel.
@@ -103,13 +105,15 @@ namespace StreamChat.Clients
         /// Returns a channel. If it doesn't exist yet with the given name, it will be created.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/creating_channels/?language=csharp</remarks>
-        Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId, string createdBy, params string[] members);
+        Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId, string createdBy,
+            params string[] members);
 
         /// <summary>
         /// Returns a channel. If it doesn't exist yet with the given name, it will be created.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/creating_channels/?language=csharp</remarks>
-        Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId, ChannelGetRequest channelRequest);
+        Task<ChannelGetResponse> GetOrCreateAsync(string channelType, string channelId,
+            ChannelGetRequest channelRequest);
 
         /// <summary>
         /// Returns a channel. If it doesn't exist yet with the given name, it will be created.
@@ -136,7 +140,8 @@ namespace StreamChat.Clients
         /// Can be used to set and unset specific fields when it is necessary to retain additional custom data fields on the object.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_update/?language=csharp</remarks>
-        Task<PartialUpdateChannelResponse> PartialUpdateAsync(string channelType, string channelId, PartialUpdateChannelRequest partialUpdateChannelRequest);
+        Task<PartialUpdateChannelResponse> PartialUpdateAsync(string channelType, string channelId,
+            PartialUpdateChannelRequest partialUpdateChannelRequest);
 
         /// <summary>
         /// <para>Queries channels.</para>
@@ -162,17 +167,25 @@ namespace StreamChat.Clients
         /// Removes member(s) from a channel.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_members/?language=csharp</remarks>
-        Task<ApiResponse> RemoveMembersAsync(string channelType, string channelId, IEnumerable<string> userIds, MessageRequest msg = null);
+        Task<ApiResponse> RemoveMembersAsync(string channelType, string channelId, IEnumerable<string> userIds,
+            MessageRequest msg = null);
 
         /// <summary>
-        /// <para>Removes all of the messages but not affect the channel data or channel members.</para>
+        /// Update channel member partially.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/node/channel_member/#update-channel-members</remarks>
+        Task<ChannelMemberResponse> UpdateMemberPartialAsync(string channelType, string channelId,
+            ChannelMemberPartialRequest channelMemberPartialRequest);
+
+        /// <summary>
+        /// <para>Removes all messages but not affect the channel data or channel members.</para>
         /// If you want to delete both channel and message data then use <see cref="DeleteAsync"/> method instead.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/truncate_channel/?language=csharp</remarks>
         Task<TruncateResponse> TruncateAsync(string channelType, string channelId);
 
         /// <summary>
-        /// <para>Removes all of the messages but not affect the channel data or channel members.</para>
+        /// <para>Removes all messages but not affect the channel data or channel members.</para>
         /// If you want to delete both channel and message data then use <see cref="DeleteAsync"/> method instead.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/truncate_channel/?language=csharp</remarks>
@@ -182,7 +195,8 @@ namespace StreamChat.Clients
         /// Invites a user to the channel.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_invites/?language=csharp/</remarks>
-        Task<UpdateChannelResponse> InviteAsync(string channelType, string channelId, string userId, MessageRequest msg = null);
+        Task<UpdateChannelResponse> InviteAsync(string channelType, string channelId, string userId,
+            MessageRequest msg = null);
 
         /// <summary>
         /// Invites a user to the channel.
@@ -194,7 +208,8 @@ namespace StreamChat.Clients
         /// Invites a user to the channel.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_invites/?language=csharp/</remarks>
-        Task<UpdateChannelResponse> InviteAsync(string channelType, string channelId, IEnumerable<string> userIds, MessageRequest msg = null);
+        Task<UpdateChannelResponse> InviteAsync(string channelType, string channelId, IEnumerable<string> userIds,
+            MessageRequest msg = null);
 
         /// <summary>
         /// Accepts an invitaton to a channel.
@@ -210,11 +225,36 @@ namespace StreamChat.Clients
 
         /// <summary>
         /// <para>Updates a channel.</para>
-        /// The update function updates all of the channel data. Any data that is present on the channel
+        /// The update function updates all channel data. Any data that is present on the channel
         /// and not included in a full update will be deleted. If you don't want that, use
         /// the <see cref="PartialUpdateAsync"/> method instead.
         /// </summary>
         /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_update/?language=csharp</remarks>
-        Task<UpdateChannelResponse> UpdateAsync(string channelType, string channelId, ChannelUpdateRequest updateRequest);
+        Task<UpdateChannelResponse> UpdateAsync(string channelType, string channelId,
+            ChannelUpdateRequest updateRequest);
+
+        /// <summary>
+        /// Pins the channel for the user.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_update/#pinning-a-channel</remarks>
+        Task<ChannelMemberResponse> PinAsync(string channelType, string channelId, string userId);
+
+        /// <summary>
+        /// Unpins the channel for the user.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_update/#pinning-a-channel</remarks>
+        Task<ChannelMemberResponse> UnpinAsync(string channelType, string channelId, string userId);
+
+        /// <summary>
+        /// Archives the channel for the user.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_update/#archiving-a-channel</remarks>
+        Task<ChannelMemberResponse> ArchiveAsync(string channelType, string channelId, string userId);
+
+        /// <summary>
+        /// Unarchives the channel for the user.
+        /// </summary>
+        /// <remarks>https://getstream.io/chat/docs/dotnet-csharp/channel_update/#archiving-a-channel</remarks>
+        Task<ChannelMemberResponse> UnarchiveAsync(string channelType, string channelId, string userId);
     }
 }

--- a/src/Models/ChannelMember.cs
+++ b/src/Models/ChannelMember.cs
@@ -10,7 +10,7 @@ namespace StreamChat.Models
         public const string Owner = "owner";
     }
 
-    public class ChannelMember
+    public class ChannelMember : CustomDataBase
     {
         public string UserId { get; set; }
         public UserRequest User { get; set; }
@@ -25,5 +25,12 @@ namespace StreamChat.Models
         public DateTimeOffset? BanExpires { get; set; }
         public bool? ShadowBanned { get; set; }
         public bool? NotificationsMuted { get; set; }
+        public DateTimeOffset? PinnedAt { get; set; }
+        public DateTimeOffset? ArchivedAt { get; set; }
+    }
+
+    public class ChannelMemberResponse : ApiResponse
+    {
+        public ChannelMember ChannelMember { get; set; }
     }
 }

--- a/src/Models/User.cs
+++ b/src/Models/User.cs
@@ -75,7 +75,7 @@ namespace StreamChat.Models
         public Dictionary<string, object> Set { get; set; }
         public IEnumerable<string> Unset { get; set; }
     }
-    
+
     public class ChannelMemberPartialRequest
     {
         public string UserId { get; set; }

--- a/src/Models/User.cs
+++ b/src/Models/User.cs
@@ -75,6 +75,13 @@ namespace StreamChat.Models
         public Dictionary<string, object> Set { get; set; }
         public IEnumerable<string> Unset { get; set; }
     }
+    
+    public class ChannelMemberPartialRequest
+    {
+        public string UserId { get; set; }
+        public Dictionary<string, object> Set { get; set; }
+        public IEnumerable<string> Unset { get; set; }
+    }
 
     public class RoleAssignment
     {

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -407,6 +407,7 @@ namespace StreamChatTests
                 Filter = new Dictionary<string, object>()
                 {
                     { "pinned", true },
+                    { "cid", channel.Cid },
                 },
                 UserId = _user1.Id,
             });
@@ -443,6 +444,7 @@ namespace StreamChatTests
                 Filter = new Dictionary<string, object>()
                 {
                     { "pinned", true },
+                    { "cid", channel.Cid },
                 },
                 UserId = _user1.Id,
             });
@@ -472,6 +474,7 @@ namespace StreamChatTests
                 Filter = new Dictionary<string, object>()
                 {
                     { "archived", true },
+                    { "cid", channel.Cid },
                 },
                 UserId = _user1.Id,
             });
@@ -508,6 +511,7 @@ namespace StreamChatTests
                 Filter = new Dictionary<string, object>()
                 {
                     { "archived", true },
+                    { "cid", channel.Cid },
                 },
                 UserId = _user1.Id,
             });

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -145,7 +145,7 @@ namespace StreamChatTests
             var resp = await _channelClient.QueryChannelsAsync(QueryChannelsOptions.Default.WithFilter(
                 new Dictionary<string, object>
                 {
-                    { "cid", new Dictionary<string, object> { { "$eq", channel.Cid } } },
+                    { "cid", channel.Cid },
                 }));
             resp.Channels.Count.Should().Be(0);
         }
@@ -176,7 +176,7 @@ namespace StreamChatTests
             var queryResp = await _channelClient.QueryChannelsAsync(QueryChannelsOptions.Default.WithFilter(
                 new Dictionary<string, object>
                 {
-                    { "cid", new Dictionary<string, object> { { "$eq", _channel.Cid } } },
+                    { "cid", _channel.Cid },
                 }));
 
             var read = queryResp.Channels[0].Reads[0];
@@ -373,12 +373,7 @@ namespace StreamChatTests
                 Id = _channel.Id,
                 FilterConditions = new Dictionary<string, object>()
                 {
-                    {
-                        "id", new Dictionary<string, object>
-                        {
-                            { "$eq", _user1.Id },
-                        }
-                    },
+                    { "id", _user1.Id },
                 },
             });
 
@@ -469,7 +464,7 @@ namespace StreamChatTests
             response.ChannelMember.ArchivedAt.Should().BeCloseTo(timestamp, TimeSpan.FromSeconds(1));
 
             // Assert query archived channel
-            var pinnedChannels = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+            var archivedChannels = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
             {
                 Filter = new Dictionary<string, object>()
                 {
@@ -479,7 +474,7 @@ namespace StreamChatTests
                 UserId = _user1.Id,
             });
 
-            pinnedChannels.Channels.Single().Channel.Cid.Should().Be(channel.Cid);
+            archivedChannels.Channels.Single().Channel.Cid.Should().Be(channel.Cid);
         }
 
         [Test]

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using StreamChat.Models;
 
@@ -406,6 +407,44 @@ namespace StreamChatTests
                 },
                 UserId = _user1.Id,
             });
+
+            if (pinnedChannels.Channels.Count == 0)
+            {
+                Console.WriteLine("No pinned channels found. Try again");
+                await Task.Delay(2000);
+
+                var pinnedChannels2 = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+                {
+                    Filter = new Dictionary<string, object>()
+                    {
+                        { "pinned", true },
+                        { "cid", channel.Cid },
+                    },
+                    UserId = _user1.Id,
+                });
+
+                Console.WriteLine("Second attempt channels: " + pinnedChannels2.Channels.Count);
+
+                var pinnedChannels3 = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+                {
+                    Filter = new Dictionary<string, object>()
+                    {
+                        { "cid", channel.Cid },
+                    },
+                    UserId = _user1.Id,
+                });
+
+                Console.WriteLine("Third attempt channels: " + pinnedChannels3.Channels.Count);
+
+                if (pinnedChannels3.Channels.Count > 0)
+                {
+                    var channelToInspect = pinnedChannels3.Channels.First();
+                    var json = JsonConvert.SerializeObject(channelToInspect);
+                    Console.WriteLine("Serialized: " + json);
+                }
+
+                return;
+            }
 
             pinnedChannels.Channels.Single().Channel.Cid.Should().Be(channel.Cid);
         }

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -408,45 +408,6 @@ namespace StreamChatTests
                 UserId = _user1.Id,
             });
 
-            if (pinnedChannels.Channels.Count == 0)
-            {
-                Console.WriteLine($"No pinned channels found. Try again. Channel Cid: {channel.Cid}, user ID: {_user1.Id}");
-                await Task.Delay(4000);
-
-                var pinnedChannels2 = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
-                {
-                    Filter = new Dictionary<string, object>()
-                    {
-                        { "pinned", true },
-                        { "cid", channel.Cid },
-                    },
-                    UserId = _user1.Id,
-                    Limit = 20,
-                });
-
-                Console.WriteLine("Second attempt channels: " + pinnedChannels2.Channels.Count);
-
-                var pinnedChannels3 = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
-                {
-                    Filter = new Dictionary<string, object>()
-                    {
-                        { "cid", channel.Cid },
-                    },
-                    UserId = _user1.Id,
-                });
-
-                Console.WriteLine("Third attempt channels: " + pinnedChannels3.Channels.Count);
-
-                if (pinnedChannels3.Channels.Count > 0)
-                {
-                    var channelToInspect = pinnedChannels3.Channels.First();
-                    var json = JsonConvert.SerializeObject(channelToInspect);
-                    Console.WriteLine("Serialized: " + json);
-                }
-
-                return;
-            }
-
             pinnedChannels.Channels.Single().Channel.Cid.Should().Be(channel.Cid);
         }
 

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -411,7 +411,7 @@ namespace StreamChatTests
             if (pinnedChannels.Channels.Count == 0)
             {
                 Console.WriteLine($"No pinned channels found. Try again. Channel Cid: {channel.Cid}, user ID: {_user1.Id}");
-                await Task.Delay(2000);
+                await Task.Delay(4000);
 
                 var pinnedChannels2 = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
                 {
@@ -421,6 +421,7 @@ namespace StreamChatTests
                         { "cid", channel.Cid },
                     },
                     UserId = _user1.Id,
+                    Limit = 20,
                 });
 
                 Console.WriteLine("Second attempt channels: " + pinnedChannels2.Channels.Count);

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -410,7 +410,7 @@ namespace StreamChatTests
 
             if (pinnedChannels.Channels.Count == 0)
             {
-                Console.WriteLine("No pinned channels found. Try again");
+                Console.WriteLine($"No pinned channels found. Try again. Channel Cid: {channel.Cid}, user ID: {_user1.Id}");
                 await Task.Delay(2000);
 
                 var pinnedChannels2 = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions

--- a/tests/DeviceClientTests.cs
+++ b/tests/DeviceClientTests.cs
@@ -27,7 +27,8 @@ namespace StreamChatTests
             await _deviceClient.AddDeviceAsync(new Device
             {
                 Id = _deviceId,
-                PushProvider = "apn",
+                PushProvider = "firebase",
+                PushProviderName = "FirebaseTestApp",
                 UserId = _user.Id,
             });
         }

--- a/tests/EventClientTests.cs
+++ b/tests/EventClientTests.cs
@@ -26,9 +26,8 @@ namespace StreamChatTests
         }
 
         [OneTimeTearDown]
-        public async Task TearownAsync()
+        public async Task TearDownAsync()
         {
-            await TryDeleteChannelAsync(_channel.Cid);
             await TryDeleteUsersAsync(_user.Id);
         }
 

--- a/tests/MessageClientTests.cs
+++ b/tests/MessageClientTests.cs
@@ -35,9 +35,8 @@ namespace StreamChatTests
         }
 
         [TearDown]
-        public async Task TearownAsync()
+        public async Task TearDownAsync()
         {
-            await TryDeleteChannelAsync(_channel.Cid);
             await TryDeleteUsersAsync(_user.Id);
         }
 

--- a/tests/MessageClientTests.cs
+++ b/tests/MessageClientTests.cs
@@ -90,7 +90,7 @@ namespace StreamChatTests
             {
                 Filter = new Dictionary<string, object>
             {
-                { "cid", new Dictionary<string, object> { { "$eq", _channel.Cid } } },
+                { "cid", _channel.Cid },
             },
                 UserId = _user.Id,
             });
@@ -103,7 +103,7 @@ namespace StreamChatTests
             {
                 Filter = new Dictionary<string, object>
             {
-                { "cid", new Dictionary<string, object> { { "$eq", _channel.Cid } } },
+                { "cid", _channel.Cid },
             },
                 UserId = _user.Id,
             });

--- a/tests/ReactionClientTests.cs
+++ b/tests/ReactionClientTests.cs
@@ -26,9 +26,8 @@ namespace StreamChatTests
         }
 
         [OneTimeTearDown]
-        public async Task OneTimeTearownAsync()
+        public async Task OneTimeTearDownAsync()
         {
-            await TryDeleteChannelAsync(_channel.Cid);
             await TryDeleteUsersAsync(_user.Id);
         }
 

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -31,6 +31,11 @@ namespace StreamChatTests
         private async Task OneTimeTearDown()
         {
             var cids = _testChannels.Select(x => x.Cid).ToArray();
+            if (cids.Length == 0)
+            {
+                return;
+            }
+
             var resp = await _channelClient.DeleteChannelsAsync(cids, hardDelete: true);
             await WaitUntilTaskSucceedsAsync(resp.TaskId);
         }

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using StreamChat.Clients;
 using StreamChat.Models;
 
@@ -23,6 +24,16 @@ namespace StreamChatTests
         protected static readonly IReactionClient _reactionClient = TestClientFactory.GetReactionClient();
         protected static readonly IUserClient _userClient = TestClientFactory.GetUserClient();
         protected static readonly ITaskClient _taskClient = TestClientFactory.GetTaskClient();
+
+        private readonly List<ChannelWithConfig> _testChannels = new List<ChannelWithConfig>();
+
+        [OneTimeTearDown]
+        private async Task OneTimeTearDown()
+        {
+            var cids = _testChannels.Select(x => x.Cid).ToArray();
+            var resp = await _channelClient.DeleteChannelsAsync(cids, hardDelete: true);
+            await WaitUntilTaskSucceedsAsync(resp.TaskId);
+        }
 
         protected async Task WaitForAsync(Func<Task<bool>> condition, int timeout = 5000, int delay = 500)
         {
@@ -62,16 +73,21 @@ namespace StreamChatTests
             return user;
         }
 
-        protected async Task<ChannelWithConfig> CreateChannelAsync(string createdByUserId, IEnumerable<string> members)
+        protected async Task<ChannelWithConfig> CreateChannelAsync(string createdByUserId, IEnumerable<string> members = null, bool autoDelete = true)
         {
             var channelResp = await _channelClient.GetOrCreateAsync("messaging", Guid.NewGuid().ToString(), new ChannelGetRequest
             {
                 Data = new ChannelRequest
                 {
-                    Members = members.Select((x, idx) => new ChannelMember { UserId = x, Role = idx == 0 ? Role.Admin : null }),
+                    Members = members?.Select((x, idx) => new ChannelMember { UserId = x, Role = idx == 0 ? Role.Admin : null }),
                     CreatedBy = new UserRequest { Id = createdByUserId },
                 },
             });
+
+            if (autoDelete)
+            {
+                _testChannels.Add(channelResp.Channel);
+            }
 
             return channelResp.Channel;
         }

--- a/tests/UserClientTests.cs
+++ b/tests/UserClientTests.cs
@@ -32,9 +32,8 @@ namespace StreamChatTests
         }
 
         [TearDown]
-        public async Task TearownAsync()
+        public async Task TeardownAsync()
         {
-            await TryDeleteChannelAsync(_channel.Cid);
             await TryDeleteUsersAsync(_user1.Id, _user2.Id);
         }
 


### PR DESCRIPTION
1. Implemented `update member partial update` endpoint + related pin for member and archive methods
2. Extended ChannelMember to support Custom data
3. Modified test's `CreateChannelAsync` to automatically delete created channels. This was needed so that tests could easily create temp channels without being concerned with the cleanup afterward. Currently, SDK reuses channels for multiple tests, but this can sometimes lead to conflicts (For example, if you archive a channel that's already archived, the `archived_at` date wouldn't match the one you expect because any subsequent archive request would get ignored). Ideally, each test would run in full data isolation.  
4. Fixed a bunch of typos