### PR TITLE
Fix deleting channels after tests

### DIFF
--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -28,16 +28,18 @@ namespace StreamChatTests
         private readonly List<ChannelWithConfig> _testChannels = new List<ChannelWithConfig>();
 
         [OneTimeTearDown]
-        private async Task OneTimeTearDown()
+        public async Task OneTimeTearDown()
         {
-            var cids = _testChannels.Select(x => x.Cid).ToArray();
-            if (cids.Length == 0)
-            {
-                return;
-            }
+            const int chunkSize = 50;
 
-            var resp = await _channelClient.DeleteChannelsAsync(cids, hardDelete: true);
-            await WaitUntilTaskSucceedsAsync(resp.TaskId);
+            var cids = _testChannels.Select(x => x.Cid).ToArray();
+            for (int i = 0; i < cids.Length; i += chunkSize)
+            {
+                var chunk = cids.Skip(i).Take(chunkSize).ToArray();
+
+                var resp = await _channelClient.DeleteChannelsAsync(chunk, hardDelete: true);
+                await WaitUntilTaskSucceedsAsync(resp.TaskId);
+            }
         }
 
         protected async Task WaitForAsync(Func<Task<bool>> condition, int timeout = 5000, int delay = 500)


### PR DESCRIPTION
Fix deleting channels after tests (TearDown needs to be public) + delete in chunks in case channels to delete count exceeds API max batch count

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
- [ ] Commit message fits [conventional commits](https://www.conventionalcommits.org). Important for [CHANGELOG](./../CHANGELOG.md) generation.

## Description of the pull request
