### PR TITLE
feat: Add support for `MemberLimit` and `MessageLimit` when querying channels.

### DIFF
--- a/src/Models/QueryOptions.cs
+++ b/src/Models/QueryOptions.cs
@@ -76,6 +76,8 @@ namespace StreamChat.Models
 
         public int Offset { get; set; } = DefaultOffset;
         public int Limit { get; set; } = DefaultLimit;
+        public int MemberLimit { get; set; }
+        public int MessageLimit { get; set; }
         public bool Presence { get; set; }
         public bool State { get; set; }
         public bool Watch { get; set; }

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -30,6 +30,10 @@ namespace StreamChatTests
             _channel = await CreateChannelAsync(createdByUserId: _user1.Id,
                 members: new[] { _user1.Id, _user2.Id, _user3.Id });
             await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text");
+            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 2");
+            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 3");
+            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 4");
+            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 5");
         }
 
         [OneTimeTearDown]
@@ -811,6 +815,68 @@ namespace StreamChatTests
             });
 
             archivedChannels.Channels.Should().NotContain(c => c.Channel.Cid == channel.Cid);
+        }
+
+        [Test]
+        public async Task TestQueryChannelsWithoutMembersLimit()
+        {
+            var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+            {
+                Filter = new Dictionary<string, object>()
+                {
+                    { "cid", _channel.Cid },
+                },
+                UserId = _user1.Id,
+            });
+            queryChannelResponse.Channels.Should().HaveCount(1);
+            queryChannelResponse.Channels.First().Members.Should().HaveCount(3);
+        }
+
+        [Test]
+        public async Task TestQueryChannelsWithMembersLimit()
+        {
+            var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+            {
+                Filter = new Dictionary<string, object>()
+                {
+                    { "cid", _channel.Cid },
+                },
+                MemberLimit = 1,
+                UserId = _user1.Id,
+            });
+            queryChannelResponse.Channels.Should().HaveCount(1);
+            queryChannelResponse.Channels.First().Members.Should().HaveCount(1);
+        }
+
+        [Test]
+        public async Task TestQueryChannelsWithoutMessageLimit()
+        {
+            var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+            {
+                Filter = new Dictionary<string, object>()
+                {
+                    { "cid", _channel.Cid },
+                },
+                UserId = _user1.Id,
+            });
+            queryChannelResponse.Channels.Should().HaveCount(1);
+            queryChannelResponse.Channels.First().Messages.Should().HaveCount(5);
+        }
+
+        [Test]
+        public async Task TestQueryChannelsWithMessageLimit()
+        {
+            var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
+            {
+                Filter = new Dictionary<string, object>()
+                {
+                    { "cid", _channel.Cid },
+                },
+                MessageLimit = 2,
+                UserId = _user1.Id,
+            });
+            queryChannelResponse.Channels.Should().HaveCount(1);
+            queryChannelResponse.Channels.First().Messages.Should().HaveCount(2);
         }
     }
 }

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using StreamChat.Models;
 
@@ -21,6 +20,7 @@ namespace StreamChatTests
         private UserRequest _user2;
         private UserRequest _user3;
         private ChannelWithConfig _channel;
+        private ChannelWithConfig _channel2;
 
         [OneTimeSetUp]
         public async Task SetupAsync()
@@ -29,11 +29,13 @@ namespace StreamChatTests
                 await UpsertNewUserAsync());
             _channel = await CreateChannelAsync(createdByUserId: _user1.Id,
                 members: new[] { _user1.Id, _user2.Id, _user3.Id });
-            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text");
-            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 2");
-            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 3");
-            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 4");
-            await _messageClient.SendMessageAsync(_channel.Type, _channel.Id, _user1.Id, "text 5");
+            _channel2 = await CreateChannelAsync(createdByUserId: _user1.Id,
+                members: new[] { _user1.Id, _user2.Id, _user3.Id });
+            await _messageClient.SendMessageAsync(_channel2.Type, _channel2.Id, _user1.Id, "text");
+            await _messageClient.SendMessageAsync(_channel2.Type, _channel2.Id, _user1.Id, "text 2");
+            await _messageClient.SendMessageAsync(_channel2.Type, _channel2.Id, _user1.Id, "text 3");
+            await _messageClient.SendMessageAsync(_channel2.Type, _channel2.Id, _user1.Id, "text 4");
+            await _messageClient.SendMessageAsync(_channel2.Type, _channel2.Id, _user1.Id, "text 5");
         }
 
         [OneTimeTearDown]
@@ -824,7 +826,7 @@ namespace StreamChatTests
             {
                 Filter = new Dictionary<string, object>()
                 {
-                    { "cid", _channel.Cid },
+                    { "cid", _channel2.Cid },
                 },
                 UserId = _user1.Id,
             });
@@ -839,7 +841,7 @@ namespace StreamChatTests
             {
                 Filter = new Dictionary<string, object>()
                 {
-                    { "cid", _channel.Cid },
+                    { "cid", _channel2.Cid },
                 },
                 MemberLimit = 1,
                 UserId = _user1.Id,
@@ -855,7 +857,7 @@ namespace StreamChatTests
             {
                 Filter = new Dictionary<string, object>()
                 {
-                    { "cid", _channel.Cid },
+                    { "cid", _channel2.Cid },
                 },
                 UserId = _user1.Id,
             });
@@ -870,7 +872,7 @@ namespace StreamChatTests
             {
                 Filter = new Dictionary<string, object>()
                 {
-                    { "cid", _channel.Cid },
+                    { "cid", _channel2.Cid },
                 },
                 MessageLimit = 2,
                 UserId = _user1.Id,

--- a/tests/ChannelClientTests.cs
+++ b/tests/ChannelClientTests.cs
@@ -820,7 +820,7 @@ namespace StreamChatTests
         }
 
         [Test]
-        public async Task TestQueryChannelsWithoutMembersLimit()
+        public async Task TestQueryChannelsWithoutMembersLimitAsync()
         {
             var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
             {
@@ -835,7 +835,7 @@ namespace StreamChatTests
         }
 
         [Test]
-        public async Task TestQueryChannelsWithMembersLimit()
+        public async Task TestQueryChannelsWithMembersLimitAsync()
         {
             var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
             {
@@ -851,7 +851,7 @@ namespace StreamChatTests
         }
 
         [Test]
-        public async Task TestQueryChannelsWithoutMessageLimit()
+        public async Task TestQueryChannelsWithoutMessageLimitAsync()
         {
             var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
             {
@@ -866,7 +866,7 @@ namespace StreamChatTests
         }
 
         [Test]
-        public async Task TestQueryChannelsWithMessageLimit()
+        public async Task TestQueryChannelsWithMessageLimitAsync()
         {
             var queryChannelResponse = await _channelClient.QueryChannelsAsync(new QueryChannelsOptions
             {


### PR DESCRIPTION
 Can be set in `QueryChannelsOptions`

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
- [ ] Commit message fits [conventional commits](https://www.conventionalcommits.org). Important for [CHANGELOG](./../CHANGELOG.md) generation.

## Description of the pull request
