### PR TITLE
[CHA-3267] before_message_send_hook_attempt_timeout_ms

### DIFF
--- a/docs/app_and_channel_settings/app_settings.md
+++ b/docs/app_and_channel_settings/app_settings.md
@@ -75,6 +75,7 @@ These 2 settings are important. Never run with disable_auth_checks or disable_pe
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------- | ------- |
 | custom_action_handler_url    | This webhook reacts to custom /slash commands and actions on those commands/                                    | -       |
 | before_message_send_hook_url | This webhook allows you to modify or moderate message content before sending it to the chat for everyone to see | -       |
+| before_message_send_hook_attempt_timeout_ms | Optional per-attempt HTTP timeout (ms) for the before-message-send hook. `0`/unset = default (1500 ms attempt / 2000 ms overall). Integer **1–5000** sets the attempt timeout; overall envelope is value + 500 ms. | -       |
 
 ### Webhooks, SQS, SNS, and pending messages
 

--- a/docs/webhooks/webhooks_overview/before_message_send_webhook.md
+++ b/docs/webhooks/webhooks_overview/before_message_send_webhook.md
@@ -13,6 +13,17 @@ await appClient.UpdateAppSettingsAsync(new AppSettingsRequest
 });
 ```
 
+## Per-attempt HTTP timeout
+
+You can optionally set `before_message_send_hook_attempt_timeout_ms` when updating app settings. **Omitted or `0`** keeps the Stream default (**1500 ms** per HTTP attempt on this hook and **2000 ms** overall for the request envelope). Values from **1** through **5000** set that per-attempt timeout; the overall envelope is the configured value **plus 500 ms**. The API rejects values outside **0–5000**.
+
+```csharp
+await appClient.UpdateAppSettingsAsync(new AppSettingsRequest
+{
+  BeforeMessageSendHookAttemptTimeoutMs = 2000,
+});
+```
+
 ## Use-cases
 
 You can use this webhook to enforce any of these rules:
@@ -156,7 +167,9 @@ Not all message fields can be rewritten by your hook handler, fields such as cre
 
 ## Performance considerations
 
-Your webhook endpoint will be part of the send message transaction, so you should avoid performing any remote calls or potentially slow operations while processing the request. Stream Chat will give your endpoint 1 second of time to reply. If your endpoint is not available (ie. returns a response with status codes 4xx or 5xx) or takes too long, Stream Chat will continue with the execution and save the message as usual.
+Your webhook endpoint will be part of the send message transaction, so you should avoid performing any remote calls or potentially slow operations while processing the request.
+
+**Timeouts:** By default, Stream allows **1500 ms** for your HTTP handler to start returning a response (per-attempt timeout), with **2000 ms** for the overall before-message-send request including internal overhead. You can raise the per-attempt budget up to **5000 ms** using `before_message_send_hook_attempt_timeout_ms` (see [Per-attempt HTTP timeout](/chat/docs/dotnet-csharp/before_message_send_webhook/#per-attempt-http-timeout)); the overall envelope is always **500 ms** above that per-attempt value. If your endpoint is unavailable (for example HTTP **4xx** or **5xx**) or too slow, Stream **fails open** for this hook: processing continues and the message is stored as usual unless your handler returns a structured rejection.
 
 To make sure that an outage on the hook does not impact your application, Stream will pause your webhook once it is considered unreachable and it will automatically resume once the webhook is found to be healthy again.
 

--- a/src/Models/AppSettings.cs
+++ b/src/Models/AppSettings.cs
@@ -179,6 +179,10 @@ namespace StreamChat.Models
         public List<string> WebhookEvents { get; set; }
         public List<string> UserSearchDisallowedRoles { get; set; }
         public string BeforeMessageSendHookUrl { get; set; }
+
+        [JsonProperty("before_message_send_hook_attempt_timeout_ms")]
+        public int? BeforeMessageSendHookAttemptTimeoutMs { get; set; }
+
         public List<string> ImageModerationLabels { get; set; }
         public bool? ImageModerationEnabled { get; set; }
         public bool? AutoTranslationEnabled { get; set; }


### PR DESCRIPTION
## Summary
- Add/support `before_message_send_hook_attempt_timeout_ms` for app settings (before-message-send webhook per-attempt timeout).

## Related
- Backend: https://github.com/GetStream/chat/pull/13541
- Docs: https://github.com/GetStream/docs-content/pull/1304

## Test plan
- [ ] Build / tests (`dotnet build` / CI)