### PR TITLE
[MOD2-1059] fix: Move testmode on check endpoint

### DIFF
--- a/src/Clients/IModerationClient.cs
+++ b/src/Clients/IModerationClient.cs
@@ -17,13 +17,15 @@ namespace StreamChat.Clients
         /// <param name="moderationPayload">Content to be checked for moderation. E.g., texts, images, videos</param>
         /// <param name="configKey">Configuration key for moderation</param>
         /// <param name="options">Additional options for moderation check</param>
+        /// <param name="testMode">When true, runs the moderation check without persisting a review queue item.</param>
         Task<ModerationCheckResponse> CheckAsync(
             string entityType,
             string entityId,
             string entityCreatorId,
             ModerationPayload moderationPayload,
             string configKey,
-            ModerationCheckOptions options = null);
+            ModerationCheckOptions options = null,
+            bool? testMode = null);
 
         /// <summary>
         /// Experimental: Check user profile for moderation.

--- a/src/Clients/ModerationClient.cs
+++ b/src/Clients/ModerationClient.cs
@@ -19,7 +19,8 @@ namespace StreamChat.Clients
             string entityCreatorId,
             ModerationPayload moderationPayload,
             string configKey,
-            ModerationCheckOptions options = null)
+            ModerationCheckOptions options = null,
+            bool? testMode = null)
         {
             var request = new
             {
@@ -29,6 +30,7 @@ namespace StreamChat.Clients
                 moderation_payload = moderationPayload,
                 config_key = configKey,
                 options,
+                test_mode = testMode,
             };
 
             return await ExecuteRequestAsync<ModerationCheckResponse>(
@@ -60,8 +62,8 @@ namespace StreamChat.Clients
                 new ModerationCheckOptions
                 {
                     ForceSync = true,
-                    TestMode = true,
-                });
+                },
+                testMode: true);
         }
     }
 }

--- a/src/Models/ModerationModels.cs
+++ b/src/Models/ModerationModels.cs
@@ -13,7 +13,6 @@ namespace StreamChat.Models
     public class ModerationCheckOptions
     {
         public bool? ForceSync { get; set; }
-        public bool? TestMode { get; set; }
     }
 
     public class UserProfileCheckRequest


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
- [ ] Commit message fits [conventional commits](https://www.conventionalcommits.org). Important for [CHANGELOG](./../CHANGELOG.md) generation.

## Description of the pull request
TestMode is now a top-level argument on the check request body.
Leaving it in the options is ineffective, so test_mode would remain unusable.